### PR TITLE
Restyle web app with Aurora design system

### DIFF
--- a/web/src/app/(app)/agents/[name]/page.tsx
+++ b/web/src/app/(app)/agents/[name]/page.tsx
@@ -8,13 +8,19 @@ import { formatPrice, formatDate } from '@/lib/formatters';
 import { PortfolioCharts } from '@/components/agents/PortfolioCharts';
 import { PricingIntelligence } from '@/components/agents/PricingIntelligence';
 import { MarketPosition } from '@/components/agents/MarketPosition';
-import { QualityScore } from '@/components/agents/QualityScore';
 import { InventoryHealth } from '@/components/agents/InventoryHealth';
 import { AgentMap } from '@/components/agents/AgentMap';
 import { AgentListings } from '@/components/agents/AgentListings';
 
 interface AgentReportPageProps {
   params: Promise<{ name: string }>;
+}
+
+function compactPrice(p: number | null | undefined): string {
+  if (p == null) return '—';
+  if (p >= 1_000_000) return `$${(p / 1_000_000).toFixed(2)}M`;
+  if (p >= 1_000) return `$${(p / 1_000).toFixed(0)}K`;
+  return `$${Math.round(p)}`;
 }
 
 export default function AgentReportPage({ params }: AgentReportPageProps) {
@@ -40,83 +46,94 @@ export default function AgentReportPage({ params }: AgentReportPageProps) {
 
   if (isLoading) {
     return (
-      <div className="p-6 space-y-6">
-        <div className="animate-pulse space-y-6">
-          <div className="h-8 bg-gray-200 rounded w-64" />
-          <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-            {Array.from({ length: 6 }).map((_, i) => (
-              <div key={i} className="h-24 bg-gray-200 rounded-lg" />
-            ))}
-          </div>
-          <div className="h-64 bg-gray-200 rounded-lg" />
-          <div className="h-64 bg-gray-200 rounded-lg" />
+      <div className="px-6 md:px-10 py-8 max-w-[1400px] mx-auto space-y-6">
+        <div className="animate-pulse h-12 bg-stone-200/50 rounded-lg w-64" />
+        <div className="grid grid-cols-2 lg:grid-cols-6 gap-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="h-24 rounded-2xl aurora-surface animate-pulse" />
+          ))}
         </div>
+        <div className="h-64 rounded-3xl aurora-surface animate-pulse" />
+        <div className="h-64 rounded-3xl aurora-surface animate-pulse" />
       </div>
     );
   }
 
   if (error || !data) {
     return (
-      <div className="p-6">
-        <Link href="/agents" className="text-blue-600 hover:underline text-sm mb-4 inline-block">&larr; Back to Agents</Link>
-        <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-center">
-          <p className="text-red-700 font-medium">Agent not found</p>
-          <p className="text-red-500 text-sm mt-1">No seller found with the name &ldquo;{sellerName}&rdquo;</p>
+      <div className="px-6 md:px-10 py-8 max-w-[1400px] mx-auto">
+        <Link href="/agents" className="aurora-pill aurora-pill-ghost mb-5">
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+          </svg>
+          Back to agents
+        </Link>
+        <div className="aurora-surface rounded-3xl p-8 text-center">
+          <p className="font-serif text-2xl text-stone-900">Agent not found</p>
+          <p className="text-sm text-stone-500 mt-1">No seller found with the name &ldquo;{sellerName}&rdquo;</p>
         </div>
       </div>
     );
   }
 
-  const { profile, metrics, portfolio, pricing, position, quality, agents, inventory, geo, listings, listingsLocations } = data;
-
-  const typeBadgeColor: Record<string, string> = {
-    agency: 'bg-purple-100 text-purple-700',
-    developer: 'bg-blue-100 text-blue-700',
-    owner: 'bg-green-100 text-green-700',
-  };
+  const { profile, metrics, portfolio, pricing, position, agents, inventory, geo, listings, listingsLocations } = data;
 
   return (
-    <div className="p-6 space-y-8 max-w-7xl">
-      {/* Breadcrumb */}
-      <Link href="/agents" className="text-blue-600 hover:underline text-sm">&larr; Back to Agents</Link>
+    <div className="px-6 md:px-10 py-8 max-w-[1400px] mx-auto space-y-10">
+      <Link href="/agents" className="aurora-pill aurora-pill-ghost">
+        <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+        </svg>
+        Back to agents
+      </Link>
 
-      {/* Section 1: Profile Header */}
-      <div className="flex flex-wrap items-start gap-4">
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-3 flex-wrap">
-            <h1 className="text-2xl font-bold text-gray-900">{profile.name}</h1>
-            {profile.type && (
-              <span className={`px-2.5 py-0.5 rounded-full text-xs font-medium ${typeBadgeColor[profile.type] || 'bg-gray-100 text-gray-700'}`}>
-                {profile.type}
+      {/* Profile */}
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="flex items-start gap-4 flex-1 min-w-0">
+          <span
+            className="w-16 h-16 rounded-3xl flex items-center justify-center font-serif text-2xl text-stone-700 shrink-0"
+            style={{ background: 'linear-gradient(135deg, #ecf3ec, #ebe4cd)' }}
+          >
+            {profile.name.charAt(0).toUpperCase()}
+          </span>
+          <div className="min-w-0">
+            <p className="text-[11px] uppercase tracking-[0.3em] text-stone-500 font-medium">Agent profile</p>
+            <h1 className="font-serif text-4xl md:text-5xl font-light tracking-tight text-stone-900 mt-1.5 break-words">
+              {profile.name}
+            </h1>
+            <div className="flex flex-wrap items-center gap-1.5 mt-3">
+              {profile.type && (
+                <span className="aurora-chip capitalize">{profile.type}</span>
+              )}
+              {profile.verified && (
+                <span className="aurora-chip aurora-chip-mint">
+                  <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
+                    <path fillRule="evenodd" d="M6.267 3.455a3.066 3.066 0 001.745-.723 3.066 3.066 0 013.976 0 3.066 3.066 0 001.745.723 3.066 3.066 0 012.812 2.812c.051.643.304 1.254.723 1.745a3.066 3.066 0 010 3.976 3.066 3.066 0 00-.723 1.745 3.066 3.066 0 01-2.812 2.812 3.066 3.066 0 00-1.745.723 3.066 3.066 0 01-3.976 0 3.066 3.066 0 00-1.745-.723 3.066 3.066 0 01-2.812-2.812 3.066 3.066 0 00-.723-1.745 3.066 3.066 0 010-3.976 3.066 3.066 0 00.723-1.745 3.066 3.066 0 012.812-2.812zm7.44 5.252a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+                  </svg>
+                  Verified
+                </span>
+              )}
+              <span className="aurora-chip aurora-chip-slate">
+                Active since {formatDate(profile.activeSince)}
               </span>
-            )}
-            {profile.verified && (
-              <span className="px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-700">
-                Verified
-              </span>
-            )}
+              <span className="aurora-chip">{profile.totalListings} total listings</span>
+            </div>
           </div>
-          <p className="text-sm text-gray-500 mt-1">
-            Active since {formatDate(profile.activeSince)} &middot; {profile.totalListings} total listings
-          </p>
         </div>
-        <div className="flex gap-2">
+        <div className="flex flex-wrap gap-2">
           {profile.whatsapp && (
             <a
               href={`https://wa.me/${profile.whatsapp.replace(/\D/g, '')}`}
               target="_blank"
               rel="noopener noreferrer"
-              className="px-3 py-1.5 text-sm bg-green-600 text-white rounded-md hover:bg-green-700 inline-flex items-center gap-1.5"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-emerald-500 text-white text-sm font-medium hover:bg-emerald-600 hover:-translate-y-0.5 transition-all shadow-md shadow-emerald-200"
             >
-              <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347z"/><path d="M12 0C5.373 0 0 5.373 0 12c0 2.625.846 5.059 2.284 7.034L.789 23.492a.5.5 0 00.612.638l4.675-1.408A11.95 11.95 0 0012 24c6.627 0 12-5.373 12-12S18.627 0 12 0zm0 22c-2.24 0-4.318-.726-6.003-1.957l-.42-.309-2.775.836.876-2.712-.338-.437A9.956 9.956 0 012 12C2 6.477 6.477 2 12 2s10 4.477 10 10-4.477 10-10 10z"/></svg>
+              <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347z"/></svg>
               WhatsApp
             </a>
           )}
           {profile.phone && (
-            <a
-              href={`tel:${profile.phone}`}
-              className="px-3 py-1.5 text-sm bg-gray-600 text-white rounded-md hover:bg-gray-700"
-            >
+            <a href={`tel:${profile.phone}`} className="aurora-pill aurora-pill-ghost">
               Call
             </a>
           )}
@@ -125,27 +142,107 @@ export default function AgentReportPage({ params }: AgentReportPageProps) {
               href={profile.profileUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="px-3 py-1.5 text-sm bg-white border text-gray-700 rounded-md hover:bg-gray-50"
+              className="aurora-pill aurora-pill-ghost"
             >
-              Profile
+              E24 profile
+              <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M14 5h5m0 0v5m0-5L10 14" />
+              </svg>
             </a>
           )}
         </div>
       </div>
 
-      {/* Section 2: Key Metrics */}
-      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-7 gap-3">
-        <MetricCard label="Total Listings" value={metrics.total} />
-        <MetricCard label="Active" value={metrics.active} />
-        <MetricCard label="Portfolio Value" value={formatPrice(metrics.portfolioValue)} />
-        <MetricCard label="Avg Price" value={formatPrice(metrics.avgPrice)} />
-        <MetricCard label="Avg $/m²" value={metrics.avgPriceSqm ? `$${metrics.avgPriceSqm.toLocaleString()}` : 'N/A'} />
-        <MetricCard label="Total Favorites" value={metrics.totalFavorites} />
-        <MetricCard label="Market Rank" value={metrics.rank ? `#${metrics.rank}` : 'N/A'} />
+      {/* Key metrics */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3">
+        <MetricCard label="Total" value={metrics.total.toLocaleString()} />
+        <MetricCard label="Active" value={metrics.active.toLocaleString()} />
+        <MetricCard label="Portfolio" value={compactPrice(metrics.portfolioValue)} />
+        <MetricCard label="Avg price" value={compactPrice(metrics.avgPrice)} />
+        <MetricCard label="Avg $/m²" value={metrics.avgPriceSqm ? `$${Math.round(metrics.avgPriceSqm).toLocaleString()}` : '—'} />
+        <MetricCard label="Market rank" value={metrics.rank ? `#${metrics.rank}` : '—'} />
       </div>
 
-      {/* Section 3: Listings */}
-      <Section title={`Listings (${listings.pagination.total})`}>
+      {/* Portfolio */}
+      <Section title="Portfolio breakdown">
+        <PortfolioCharts
+          categorySplit={portfolio.categorySplit}
+          subcategorySplit={portfolio.subcategorySplit}
+          priceRanges={portfolio.priceRanges}
+        />
+      </Section>
+
+      {/* Pricing */}
+      <Section title="Pricing intelligence">
+        <PricingIntelligence
+          vsMarket={pricing.vsMarket}
+          vsMarketSqm={pricing.vsMarketSqm}
+          priceDrops={pricing.priceDrops}
+        />
+      </Section>
+
+      {/* Market position */}
+      <Section title="Market position">
+        <MarketPosition
+          rank={position.rank}
+          totalSellers={position.totalSellers}
+          areaPositions={position.areaPositions}
+          competitors={position.competitors}
+        />
+      </Section>
+
+      {/* Inventory health */}
+      <Section title="Inventory health">
+        <InventoryHealth
+          domDistribution={inventory.domDistribution}
+          active={inventory.active}
+          stale={inventory.stale}
+          removed={inventory.removed}
+          avgDom={inventory.avgDom}
+        />
+      </Section>
+
+      {/* Geographic coverage */}
+      <Section title="Geographic coverage">
+        <div className="rounded-2xl aurora-surface overflow-hidden">
+          <AgentMap listings={geo} />
+        </div>
+      </Section>
+
+      {/* Individual agents (only for agencies) */}
+      {agents && agents.length > 0 && (
+        <Section title={`Individual agents (${agents.length})`}>
+          <div className="aurora-surface rounded-2xl overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-[11px] uppercase tracking-wider text-stone-500 border-b border-stone-200/60">
+                  <th className="px-4 py-3 font-medium">Agent name</th>
+                  <th className="px-4 py-3 text-right font-medium">Listings</th>
+                  <th className="px-4 py-3 text-right font-medium">Portfolio</th>
+                  <th className="px-4 py-3 text-right font-medium">Avg price</th>
+                </tr>
+              </thead>
+              <tbody>
+                {agents.map((agent: { name: string; listingCount: number; portfolioValue: number; avgPrice: number }) => (
+                  <tr key={agent.name} className="border-b border-stone-200/40 last:border-0 hover:bg-white/50 transition-colors">
+                    <td className="px-4 py-3 font-medium">
+                      <Link href={`/agents/${encodeURIComponent(agent.name)}`} className="text-stone-900 underline-offset-4 hover:underline">
+                        {agent.name}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-3 text-right tabular-nums">{agent.listingCount}</td>
+                    <td className="px-4 py-3 text-right tabular-nums">{compactPrice(agent.portfolioValue)}</td>
+                    <td className="px-4 py-3 text-right tabular-nums">{compactPrice(agent.avgPrice)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Section>
+      )}
+
+      {/* Listings — last */}
+      <Section title={`Listings (${listings.pagination.total.toLocaleString()})`}>
         <AgentListings
           listings={listings.data}
           pagination={listings.pagination}
@@ -157,100 +254,15 @@ export default function AgentReportPage({ params }: AgentReportPageProps) {
           onStatusChange={(s) => { setListingsStatus(s); setListingsPage(1); }}
         />
       </Section>
-
-      {/* Section 4: Portfolio Breakdown */}
-      <Section title="Portfolio Breakdown">
-        <PortfolioCharts
-          categorySplit={portfolio.categorySplit}
-          subcategorySplit={portfolio.subcategorySplit}
-          priceRanges={portfolio.priceRanges}
-        />
-      </Section>
-
-      {/* Section 4: Pricing Intelligence */}
-      <Section title="Pricing Intelligence">
-        <PricingIntelligence
-          vsMarket={pricing.vsMarket}
-          vsMarketSqm={pricing.vsMarketSqm}
-          priceDrops={pricing.priceDrops}
-        />
-      </Section>
-
-      {/* Section 5: Market Position */}
-      <Section title="Market Position">
-        <MarketPosition
-          rank={position.rank}
-          totalSellers={position.totalSellers}
-          areaPositions={position.areaPositions}
-          competitors={position.competitors}
-        />
-      </Section>
-
-      {/* Section 6: Listing Quality Score */}
-      <Section title="Listing Quality Score">
-        <QualityScore
-          composite={quality.composite}
-          engagement={quality.engagement}
-          visibility={quality.visibility}
-          presentation={quality.presentation}
-          completeness={quality.completeness}
-          raw={quality.raw}
-        />
-      </Section>
-
-      {/* Section 7: Individual Agents */}
-      {agents && agents.length > 0 && (
-        <Section title={`Individual Agents (${agents.length})`}>
-          <div className="bg-white rounded-lg border overflow-hidden">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b bg-gray-50 text-left text-gray-500 text-xs uppercase">
-                  <th className="px-4 py-3">Agent Name</th>
-                  <th className="px-4 py-3 text-right">Listings</th>
-                  <th className="px-4 py-3 text-right">Portfolio Value</th>
-                  <th className="px-4 py-3 text-right">Avg Price</th>
-                </tr>
-              </thead>
-              <tbody>
-                {agents.map((agent: { name: string; listingCount: number; portfolioValue: number; avgPrice: number }) => (
-                  <tr key={agent.name} className="border-b hover:bg-gray-50 transition-colors">
-                    <td className="px-4 py-3 font-medium"><Link href={`/agents/${encodeURIComponent(agent.name)}`} className="text-blue-600 hover:underline">{agent.name}</Link></td>
-                    <td className="px-4 py-3 text-right">{agent.listingCount}</td>
-                    <td className="px-4 py-3 text-right">{formatPrice(agent.portfolioValue)}</td>
-                    <td className="px-4 py-3 text-right">{formatPrice(agent.avgPrice)}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </Section>
-      )}
-
-      {/* Section 8: Inventory Health */}
-      <Section title="Inventory Health">
-        <InventoryHealth
-          domDistribution={inventory.domDistribution}
-          active={inventory.active}
-          stale={inventory.stale}
-          removed={inventory.removed}
-          avgDom={inventory.avgDom}
-        />
-      </Section>
-
-      {/* Section 8: Geographic Coverage */}
-      <Section title="Geographic Coverage">
-        <AgentMap listings={geo} />
-      </Section>
-
     </div>
   );
 }
 
-function MetricCard({ label, value }: { label: string; value: string | number }) {
+function MetricCard({ label, value }: { label: string; value: string }) {
   return (
-    <div className="bg-white rounded-lg border p-3">
-      <p className="text-xs text-gray-500 uppercase tracking-wide">{label}</p>
-      <p className="text-lg font-bold text-gray-900 mt-0.5">{value}</p>
+    <div className="aurora-surface rounded-2xl p-4">
+      <p className="text-[10px] uppercase tracking-[0.2em] text-stone-500 font-medium">{label}</p>
+      <p className="font-serif text-2xl font-light text-stone-900 mt-1.5 tabular-nums">{value}</p>
     </div>
   );
 }
@@ -258,7 +270,9 @@ function MetricCard({ label, value }: { label: string; value: string | number })
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <div>
-      <h2 className="text-lg font-semibold text-gray-900 mb-4">{title}</h2>
+      <h2 className="font-serif text-2xl text-stone-900 mb-4">
+        <span className="aurora-rule">{title}</span>
+      </h2>
       {children}
     </div>
   );

--- a/web/src/app/(app)/agents/page.tsx
+++ b/web/src/app/(app)/agents/page.tsx
@@ -8,8 +8,16 @@ function AgentsContent() {
   useUser({ or: 'redirect' });
 
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold text-gray-900 mb-6">Agents & Sellers</h1>
+    <div className="px-6 md:px-10 py-8 max-w-[1500px] mx-auto">
+      <div className="flex flex-wrap items-end justify-between gap-4 mb-8">
+        <div>
+          <p className="text-[11px] uppercase tracking-[0.3em] text-stone-500 font-medium">Network</p>
+          <h1 className="font-serif text-4xl md:text-5xl font-light tracking-tight text-stone-900 mt-1.5">
+            Agents <span className="italic">&amp; sellers</span>
+          </h1>
+          <p className="text-sm text-stone-500 mt-2">Leaderboards by listing volume, value, and average price.</p>
+        </div>
+      </div>
       <AgentLeaderboard />
     </div>
   );
@@ -17,7 +25,11 @@ function AgentsContent() {
 
 export default function AgentsPage() {
   return (
-    <Suspense fallback={<div className="p-6"><div className="animate-pulse h-96 bg-gray-200 rounded-lg" /></div>}>
+    <Suspense fallback={
+      <div className="px-6 md:px-10 py-8 max-w-[1500px] mx-auto">
+        <div className="animate-pulse h-96 rounded-3xl aurora-surface" />
+      </div>
+    }>
       <AgentsContent />
     </Suspense>
   );

--- a/web/src/app/(app)/aurora-skin.css
+++ b/web/src/app/(app)/aurora-skin.css
@@ -1,0 +1,169 @@
+/* Global Aurora skin — calm sage/cream/charcoal palette */
+.aurora-skin {
+  --aurora-ink: #1a1a1a;
+  --aurora-ink-soft: #2d2d2d;
+  --aurora-mute: #78716c;
+  --aurora-line: #e7e5e4;
+
+  --aurora-sage: #6b8e6b;
+  --aurora-sage-deep: #4a6b4a;
+  --aurora-sage-soft: #c8dcc7;
+  --aurora-mint: #ecf3ec;
+
+  --aurora-sand: #c9b896;
+  --aurora-sand-soft: #ebe4cd;
+  --aurora-cream: #f5f1e8;
+
+  --aurora-slate: #94a3b8;
+  --aurora-slate-soft: #e2e8f0;
+
+  --aurora-card: rgba(255, 255, 255, 0.7);
+  --aurora-card-strong: rgba(255, 255, 255, 0.88);
+
+  --font-serif: var(--font-fraunces), 'Iowan Old Style', 'Georgia', serif;
+
+  font-family: var(--font-geist-sans), system-ui, sans-serif;
+  color: var(--aurora-ink);
+}
+
+.aurora-skin .font-serif {
+  font-family: var(--font-serif);
+  font-feature-settings: 'ss01' on, 'ss02' on;
+}
+
+/* Soft cream→mint backdrop */
+.aurora-bg {
+  position: relative;
+  background:
+    radial-gradient(60rem 50rem at -10% -10%, rgba(168, 196, 168, 0.22), transparent 60%),
+    radial-gradient(50rem 40rem at 110% 20%, rgba(212, 197, 160, 0.18), transparent 60%),
+    radial-gradient(50rem 40rem at 50% 110%, rgba(184, 184, 200, 0.14), transparent 60%),
+    linear-gradient(180deg, #f6f7f3 0%, #f2f5ee 50%, #eef3ea 100%);
+  background-attachment: fixed;
+}
+
+/* Glass surface */
+.aurora-surface {
+  background: var(--aurora-card);
+  backdrop-filter: saturate(140%) blur(14px);
+  -webkit-backdrop-filter: saturate(140%) blur(14px);
+  border: 1px solid rgba(255, 255, 255, 0.8);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.7) inset,
+    0 8px 24px -16px rgba(28, 28, 28, 0.10);
+}
+
+.aurora-surface-strong {
+  background: var(--aurora-card-strong);
+  border-color: rgba(255, 255, 255, 0.9);
+}
+
+.aurora-surface-soft {
+  background: rgba(255, 255, 255, 0.45);
+  backdrop-filter: saturate(140%) blur(10px);
+  -webkit-backdrop-filter: saturate(140%) blur(10px);
+  border: 1px solid rgba(255, 255, 255, 0.65);
+}
+
+/* Pill button */
+.aurora-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 1rem;
+  border-radius: 9999px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  transition: all 0.18s ease;
+  white-space: nowrap;
+}
+
+.aurora-pill-primary {
+  background: var(--aurora-ink);
+  color: white;
+  box-shadow: 0 2px 0 rgba(255, 255, 255, 0.12) inset, 0 8px 20px -10px rgba(0, 0, 0, 0.4);
+}
+
+.aurora-pill-primary:hover {
+  background: #2d2d2d;
+  transform: translateY(-1px);
+}
+
+.aurora-pill-ghost {
+  background: rgba(255, 255, 255, 0.55);
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  backdrop-filter: blur(8px);
+  color: var(--aurora-ink-soft);
+}
+
+.aurora-pill-ghost:hover {
+  background: rgba(255, 255, 255, 0.95);
+  color: var(--aurora-ink);
+}
+
+.aurora-pill-sage {
+  background: var(--aurora-sage);
+  color: white;
+  box-shadow: 0 2px 0 rgba(255, 255, 255, 0.18) inset, 0 6px 16px -6px rgba(74, 107, 74, 0.4);
+}
+
+.aurora-pill-sage:hover {
+  background: var(--aurora-sage-deep);
+  transform: translateY(-1px);
+}
+
+/* Tag chips */
+.aurora-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.125rem 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(0, 0, 0, 0.05);
+  color: var(--aurora-ink-soft);
+}
+
+.aurora-chip-mint  { background: #ecf3ec; color: #4a6b4a; border-color: #d6e6d4; }
+.aurora-chip-sand  { background: #f5efe0; color: #8b7949; border-color: #ebe2cd; }
+.aurora-chip-slate { background: #f1f5f9; color: #475569; border-color: #e2e8f0; }
+.aurora-chip-ink   { background: #1a1a1a; color: #f5f5f4; border-color: #1a1a1a; }
+.aurora-chip-warn  { background: #fef3e6; color: #9a3412; border-color: #fde6c8; }
+
+/* Soft input */
+.aurora-input {
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  color: var(--aurora-ink);
+  transition: all 0.15s ease;
+}
+
+.aurora-input:focus {
+  outline: none;
+  background: rgba(255, 255, 255, 0.98);
+  border-color: var(--aurora-sage);
+  box-shadow: 0 0 0 4px rgba(107, 142, 107, 0.18);
+}
+
+/* Section heading underline */
+.aurora-rule {
+  display: inline-block;
+  padding-bottom: 0.25rem;
+  background-image: linear-gradient(to right, var(--aurora-sage), rgba(107, 142, 107, 0));
+  background-position: 0 100%;
+  background-size: 60% 2px;
+  background-repeat: no-repeat;
+}
+
+@keyframes aurora-drift {
+  0%, 100% { transform: translate3d(0, 0, 0); }
+  50% { transform: translate3d(2%, -1%, 0); }
+}
+
+.aurora-drift { animation: aurora-drift 16s ease-in-out infinite; }

--- a/web/src/app/(app)/crawl-history/page.tsx
+++ b/web/src/app/(app)/crawl-history/page.tsx
@@ -8,8 +8,14 @@ function CrawlHistoryContent() {
   useUser({ or: 'redirect' });
 
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold text-gray-900 mb-6">Crawl History</h1>
+    <div className="px-6 md:px-10 py-8 max-w-[1500px] mx-auto">
+      <div className="mb-8">
+        <p className="text-[11px] uppercase tracking-[0.3em] text-stone-500 font-medium">Operations</p>
+        <h1 className="font-serif text-4xl md:text-5xl font-light tracking-tight text-stone-900 mt-1.5">
+          Crawl <span className="italic">history</span>
+        </h1>
+        <p className="text-sm text-stone-500 mt-2">Recent runs, throughput, and errors.</p>
+      </div>
       <CrawlHistory />
     </div>
   );
@@ -17,7 +23,11 @@ function CrawlHistoryContent() {
 
 export default function CrawlHistoryPage() {
   return (
-    <Suspense fallback={<div className="p-6"><div className="animate-pulse h-96 bg-gray-200 rounded-lg" /></div>}>
+    <Suspense fallback={
+      <div className="px-6 md:px-10 py-8 max-w-[1500px] mx-auto">
+        <div className="animate-pulse h-96 rounded-3xl aurora-surface" />
+      </div>
+    }>
       <CrawlHistoryContent />
     </Suspense>
   );

--- a/web/src/app/(app)/layout.tsx
+++ b/web/src/app/(app)/layout.tsx
@@ -1,8 +1,18 @@
 'use client';
 
 import { Suspense } from 'react';
+import { Fraunces } from 'next/font/google';
 import { useUser } from '@stackframe/stack';
 import { Sidebar } from '@/components/layout/Sidebar';
+import './aurora-skin.css';
+
+const fraunces = Fraunces({
+  subsets: ['latin'],
+  variable: '--font-fraunces',
+  weight: ['300', '400', '500', '600'],
+  style: ['normal', 'italic'],
+  display: 'swap',
+});
 
 function AuthenticatedLayout({ children }: { children: React.ReactNode }) {
   const user = useUser({ or: 'redirect' });
@@ -10,9 +20,9 @@ function AuthenticatedLayout({ children }: { children: React.ReactNode }) {
   if (!user) return null;
 
   return (
-    <div className="flex h-screen overflow-hidden">
+    <div className={`${fraunces.variable} aurora-skin flex h-screen overflow-hidden`}>
       <Sidebar />
-      <main className="flex-1 overflow-auto bg-gray-50 pt-14 md:pt-0">
+      <main className="aurora-bg flex-1 overflow-auto pt-14 md:pt-0">
         {children}
       </main>
     </div>
@@ -26,8 +36,8 @@ export default function AppLayout({
 }) {
   return (
     <Suspense fallback={
-      <div className="flex items-center justify-center h-screen bg-gray-50">
-        <div className="text-gray-500">Loading...</div>
+      <div className={`${fraunces.variable} aurora-skin aurora-bg flex items-center justify-center h-screen`}>
+        <div className="font-serif italic text-stone-500 text-lg">Loading…</div>
       </div>
     }>
       <AuthenticatedLayout>{children}</AuthenticatedLayout>

--- a/web/src/app/(app)/listings/page.tsx
+++ b/web/src/app/(app)/listings/page.tsx
@@ -8,7 +8,6 @@ import { ListingFilters } from '@/components/listings/ListingFilters';
 import { ListingGrid } from '@/components/listings/ListingGrid';
 import { ListingSortBar } from '@/components/listings/ListingSortBar';
 import { SaveSearchModal } from '@/components/saved-searches/SaveSearchModal';
-import { DEFAULT_PAGE_SIZE } from '@/lib/constants';
 
 function ListingsContent() {
   useUser({ or: 'redirect' });
@@ -45,51 +44,131 @@ function ListingsContent() {
     if (key !== 'page' && key !== 'limit') currentFilters[key] = value;
   });
 
+  const activeChips: Array<{ key: string; label: string }> = [];
+  if (currentFilters.q) activeChips.push({ key: 'q', label: `"${currentFilters.q}"` });
+  if (currentFilters.category) activeChips.push({ key: 'category', label: currentFilters.category });
+  if (currentFilters.subcategory) activeChips.push({ key: 'subcategory', label: currentFilters.subcategory });
+  if (currentFilters.location) activeChips.push({ key: 'location', label: currentFilters.location });
+  if (currentFilters.city) activeChips.push({ key: 'city', label: currentFilters.city });
+  if (currentFilters.priceMin || currentFilters.priceMax) {
+    activeChips.push({ key: 'price', label: `$${currentFilters.priceMin || '0'} – $${currentFilters.priceMax || '∞'}` });
+  }
+  if (currentFilters.bedroomsMin) activeChips.push({ key: 'bedroomsMin', label: `${currentFilters.bedroomsMin}+ bd` });
+
+  const clearChip = (key: string) => {
+    if (key === 'price') {
+      updateParams({ priceMin: undefined, priceMax: undefined });
+    } else {
+      updateParams({ [key]: undefined });
+    }
+  };
+
   return (
-    <div className="p-6">
-      <div className="flex items-center justify-between mb-4">
-        <h1 className="text-2xl font-bold text-gray-900">Browse Listings</h1>
-        {Object.keys(currentFilters).length > 0 && (
+    <div className="px-6 md:px-10 py-8 max-w-[1500px] mx-auto">
+      {/* Hero */}
+      <div className="flex flex-wrap items-end justify-between gap-4 mb-8">
+        <div>
+          <p className="text-[11px] uppercase tracking-[0.3em] text-stone-500 font-medium">
+            Inventory
+          </p>
+          <h1 className="font-serif text-4xl md:text-5xl font-light tracking-tight text-stone-900 mt-1.5">
+            Browse <span className="italic">properties</span>
+          </h1>
+          <p className="text-sm text-stone-500 mt-2">
+            {isLoading ? 'Loading…' : (
+              data?.pagination?.total != null
+                ? <>{data.pagination.total.toLocaleString()} matching listings</>
+                : 'Filter, sort and save searches'
+            )}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {Object.keys(currentFilters).length > 0 && (
+            <button
+              onClick={() => setShowSaveModal(true)}
+              className="aurora-pill aurora-pill-primary"
+            >
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-4-7 4V5z" />
+              </svg>
+              Save search
+            </button>
+          )}
           <button
-            onClick={() => setShowSaveModal(true)}
-            className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700"
+            onClick={() => router.push('/saved-searches')}
+            className="aurora-pill aurora-pill-ghost"
           >
-            Save Search
+            Saved searches
           </button>
-        )}
+        </div>
       </div>
+
       <ListingFilters searchParams={searchParams} onUpdate={updateParams} />
+
+      {/* Active filter chips */}
+      {activeChips.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2 mb-4">
+          <span className="text-[11px] uppercase tracking-wider text-stone-500 font-medium">Active</span>
+          {activeChips.map(chip => (
+            <button
+              key={chip.key}
+              onClick={() => clearChip(chip.key)}
+              className="aurora-chip hover:bg-stone-900 hover:text-white hover:border-stone-900 transition-colors capitalize"
+            >
+              {chip.label}
+              <span className="ml-1 text-stone-400">×</span>
+            </button>
+          ))}
+          {activeChips.length > 1 && (
+            <button
+              onClick={() => {
+                const next = new URLSearchParams();
+                router.push(`/listings?${next.toString()}`);
+              }}
+              className="text-xs text-stone-500 hover:text-stone-900 underline-offset-4 hover:underline ml-1"
+            >
+              Clear all
+            </button>
+          )}
+        </div>
+      )}
+
       <ListingSortBar
         searchParams={searchParams}
         onUpdate={updateParams}
         total={data?.pagination?.total}
         isLoading={isLoading}
       />
+
       <ListingGrid
         listings={data?.data || []}
         isLoading={isLoading}
       />
+
       {data?.pagination && data.pagination.totalPages > 1 && (
-        <div className="flex justify-center items-center gap-2 mt-6">
+        <div className="flex justify-center items-center gap-3 mt-10">
           <button
             onClick={() => updateParams({ page: String(page - 1) })}
             disabled={page <= 1}
-            className="px-3 py-1.5 text-sm bg-white border rounded disabled:opacity-50 hover:bg-gray-50"
+            className="aurora-pill aurora-pill-ghost disabled:opacity-40 disabled:cursor-not-allowed"
           >
-            Previous
+            ← Previous
           </button>
-          <span className="text-sm text-gray-600">
-            Page {page} of {data.pagination.totalPages}
-          </span>
+          <div className="aurora-surface px-4 py-2 rounded-full text-sm text-stone-700">
+            <span className="font-serif text-stone-900">{page}</span>
+            <span className="text-stone-400 mx-2">/</span>
+            <span className="text-stone-500">{data.pagination.totalPages}</span>
+          </div>
           <button
             onClick={() => updateParams({ page: String(page + 1) })}
             disabled={page >= data.pagination.totalPages}
-            className="px-3 py-1.5 text-sm bg-white border rounded disabled:opacity-50 hover:bg-gray-50"
+            className="aurora-pill aurora-pill-ghost disabled:opacity-40 disabled:cursor-not-allowed"
           >
-            Next
+            Next →
           </button>
         </div>
       )}
+
       {showSaveModal && (
         <SaveSearchModal
           filters={currentFilters}
@@ -102,7 +181,11 @@ function ListingsContent() {
 
 export default function ListingsPage() {
   return (
-    <Suspense fallback={<div className="p-6"><div className="animate-pulse h-96 bg-gray-200 rounded-lg" /></div>}>
+    <Suspense fallback={
+      <div className="px-6 md:px-10 py-8 max-w-[1500px] mx-auto">
+        <div className="animate-pulse h-96 rounded-3xl aurora-surface" />
+      </div>
+    }>
       <ListingsContent />
     </Suspense>
   );

--- a/web/src/app/(app)/loading.tsx
+++ b/web/src/app/(app)/loading.tsx
@@ -1,7 +1,7 @@
 export default function Loading() {
   return (
-    <div className="flex items-center justify-center h-full">
-      <div className="text-gray-500">Loading...</div>
+    <div className="flex items-center justify-center h-full p-10">
+      <div className="font-serif italic text-stone-500 text-2xl">Loading…</div>
     </div>
   );
 }

--- a/web/src/app/(app)/map/page.tsx
+++ b/web/src/app/(app)/map/page.tsx
@@ -9,7 +9,7 @@ import { ListingFilters } from '@/components/listings/ListingFilters';
 
 const MapView = dynamic(() => import('@/components/map/MapView').then(m => ({ default: m.MapView })), {
   ssr: false,
-  loading: () => <div className="w-full h-[calc(100vh-200px)] bg-gray-100 animate-pulse rounded-lg" />,
+  loading: () => <div className="w-full h-[calc(100vh-260px)] aurora-surface rounded-3xl animate-pulse" />,
 });
 
 function MapContent() {
@@ -22,7 +22,7 @@ function MapContent() {
   params.set('limit', '500');
   const queryString = params.toString();
 
-  const { data } = useQuery({
+  const { data, isLoading } = useQuery({
     queryKey: ['map-listings', queryString],
     queryFn: () => fetch(`/api/listings?${queryString}`).then(r => r.json()),
   });
@@ -39,20 +39,29 @@ function MapContent() {
     router.push(`/map?${p.toString()}`);
   }
 
-  const handleBoundsChange = useCallback((bounds: { latMin: number; latMax: number; lngMin: number; lngMax: number }) => {
-    // Could update URL params here for deep-linking map viewport
+  const handleBoundsChange = useCallback((_bounds: { latMin: number; latMax: number; lngMin: number; lngMax: number }) => {
+    // future deep-linking
   }, []);
 
   const listings = (data?.data || []).filter((l: { latitude: number | null; longitude: number | null }) => l.latitude && l.longitude);
 
   return (
-    <div className="flex flex-col h-full">
-      <div className="p-4 pb-0">
-        <h1 className="text-2xl font-bold text-gray-900 mb-3">Map View</h1>
-        <ListingFilters searchParams={searchParams} onUpdate={updateParams} />
-        <p className="text-sm text-gray-500 mb-3">{listings.length} properties with coordinates</p>
+    <div className="flex flex-col h-full px-6 md:px-10 py-8 max-w-[1500px] mx-auto w-full">
+      <div className="flex flex-wrap items-end justify-between gap-4 mb-6">
+        <div>
+          <p className="text-[11px] uppercase tracking-[0.3em] text-stone-500 font-medium">Geography</p>
+          <h1 className="font-serif text-4xl md:text-5xl font-light tracking-tight text-stone-900 mt-1.5">
+            Map <span className="italic">view</span>
+          </h1>
+          <p className="text-sm text-stone-500 mt-2">
+            {isLoading ? 'Loading…' : `${listings.length.toLocaleString()} properties with coordinates`}
+          </p>
+        </div>
       </div>
-      <div className="flex-1 px-4 pb-4">
+
+      <ListingFilters searchParams={searchParams} onUpdate={updateParams} />
+
+      <div className="flex-1 mt-1 rounded-3xl overflow-hidden aurora-surface">
         <MapView listings={listings} onBoundsChange={handleBoundsChange} />
       </div>
     </div>
@@ -61,7 +70,11 @@ function MapContent() {
 
 export default function MapPage() {
   return (
-    <Suspense fallback={<div className="p-6"><div className="animate-pulse h-96 bg-gray-200 rounded-lg" /></div>}>
+    <Suspense fallback={
+      <div className="px-6 md:px-10 py-8 max-w-[1500px] mx-auto">
+        <div className="animate-pulse h-96 rounded-3xl aurora-surface" />
+      </div>
+    }>
       <MapContent />
     </Suspense>
   );

--- a/web/src/app/(app)/page.tsx
+++ b/web/src/app/(app)/page.tsx
@@ -1,10 +1,22 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useUser } from '@stackframe/stack';
-import { formatPrice, formatRelativeDate, formatArea } from '@/lib/formatters';
 import Link from 'next/link';
+import { formatRelativeDate } from '@/lib/formatters';
+import {
+  ResponsiveContainer,
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+  PieChart,
+  Pie,
+  Cell,
+} from 'recharts';
 
 interface ListingItem {
   adId: string;
@@ -18,25 +30,23 @@ interface ListingItem {
   firstSeenAt: string;
 }
 
-interface CategoryRow {
-  category: string;
-  subcategory: string;
-  total: number;
-  active: number;
-  avgPrice: number | null;
-  minPrice: number | null;
-  maxPrice: number | null;
-  newThisWeek: number;
-}
-
-interface LocationRow {
-  city: string;
-  location: string | null;
-  category: string;
-  subcategory: string;
-  active: number;
-  avgPrice: number | null;
-  newThisWeek: number;
+interface SummaryData {
+  stats: {
+    activeListings: number;
+    newToday: number;
+    newThisWeek: number;
+    totalFavorites: number;
+    avgPriceSale: number | null;
+    avgPriceRent: number | null;
+    activeSellers: number;
+  };
+  latestListings: ListingItem[];
+  lastCrawl: {
+    status: string;
+    startedAt: string;
+    durationSecs: number | null;
+    listingsNew: number;
+  } | null;
 }
 
 interface SavedSearchPreview {
@@ -46,452 +56,45 @@ interface SavedSearchPreview {
   listings: ListingItem[];
 }
 
-function formatCompactPrice(price: number | null | undefined): string {
-  if (price == null) return '—';
-  if (price >= 1_000_000) return `$${(price / 1_000_000).toFixed(1)}M`;
-  if (price >= 1_000) return `$${(price / 1_000).toFixed(0)}K`;
-  return `$${price.toFixed(0)}`;
+interface SearchesData {
+  savedSearches: SavedSearchPreview[];
+  lastCrawlStart: string | null;
 }
 
-type Tab = 'summary' | 'market' | 'searches';
-
-export default function DashboardPage() {
-  useUser({ or: 'redirect' });
-  const [tab, setTab] = useState<Tab>('summary');
-
-  return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold text-gray-900 mb-4">Dashboard</h1>
-
-      {/* Tabs */}
-      <div className="flex gap-1 mb-6 border-b">
-        {([
-          { key: 'summary' as Tab, label: 'Summary' },
-          { key: 'market' as Tab, label: 'Market Overview' },
-          { key: 'searches' as Tab, label: 'Saved Searches' },
-        ]).map(t => (
-          <button
-            key={t.key}
-            onClick={() => setTab(t.key)}
-            className={`px-4 py-2 text-sm font-medium border-b-2 transition-colors ${
-              tab === t.key
-                ? 'border-blue-600 text-blue-600'
-                : 'border-transparent text-gray-500 hover:text-gray-700'
-            }`}
-          >
-            {t.label}
-          </button>
-        ))}
-      </div>
-
-      {tab === 'summary' && <SummaryTab />}
-      {tab === 'market' && <MarketTab />}
-      {tab === 'searches' && <SearchesTab />}
-    </div>
-  );
+interface TrendsData {
+  dailyTrend: Array<{ day: string; added: number; removed: number }>;
+  topCities: Array<{ city: string; active: number; newThisWeek: number; avgSale: number | null; avgRent: number | null }>;
+  recentCrawls: Array<{ id: number; status: string; startedAt: string; listingsNew: number; durationSecs: number | null }>;
+  priceDistribution: Array<{ bucket: string; count: number }>;
+  categoryShare: Array<{ category: string; active: number }>;
 }
 
-/* ─── Summary Tab ────────────────────────────────────────────────────────── */
+const PALETTE = {
+  ink: '#1a1a1a',
+  sage: '#6b8e6b',
+  sageDeep: '#4a6b4a',
+  sageSoft: '#c8dcc7',
+  sand: '#c9b896',
+  sandSoft: '#ebe4cd',
+  slate: '#94a3b8',
+  slateSoft: '#cfd8e3',
+};
 
-function SummaryTab() {
-  const { data, isLoading } = useQuery({
-    queryKey: ['dashboard', 'summary'],
-    queryFn: () => fetch('/api/dashboard?tab=summary').then(r => r.json()),
-  });
-
-  if (isLoading || !data) {
-    return (
-      <div className="animate-pulse space-y-4">
-        <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-          {[...Array(4)].map((_, i) => <div key={i} className="h-24 bg-gray-200 rounded-lg" />)}
-        </div>
-        <div className="h-64 bg-gray-200 rounded-lg" />
-      </div>
-    );
-  }
-
-  const { stats, latestListings, lastCrawl } = data;
-
-  return (
-    <div className="space-y-6">
-      {/* Stats row */}
-      <div className="grid grid-cols-2 lg:grid-cols-5 gap-4">
-        <StatCard label="Active Listings" value={stats.activeListings.toLocaleString()} />
-        <StatCard label="New This Week" value={stats.newThisWeek.toLocaleString()} accent />
-        <StatCard label="Avg Sale Price" value={formatCompactPrice(stats.avgPriceSale)} />
-        <StatCard label="Avg Rent Price" value={formatCompactPrice(stats.avgPriceRent)} />
-        <StatCard label="Active Sellers" value={stats.activeSellers.toLocaleString()} />
-      </div>
-
-      {/* Last crawl */}
-      {lastCrawl && (
-        <div className="bg-white rounded-lg border p-4">
-          <h2 className="text-lg font-semibold text-gray-900 mb-2">Last Crawl</h2>
-          <div className="flex flex-wrap gap-x-6 gap-y-1 text-sm text-gray-600">
-            <span>Status: <span className={lastCrawl.status === 'completed' ? 'text-green-600 font-medium' : 'text-yellow-600 font-medium'}>{lastCrawl.status}</span></span>
-            <span>Started: {formatRelativeDate(lastCrawl.startedAt)}</span>
-            {lastCrawl.durationSecs && <span>Duration: {lastCrawl.durationSecs}s</span>}
-            {lastCrawl.listingsNew > 0 && <span className="text-green-600 font-medium">+{lastCrawl.listingsNew} new</span>}
-            <Link href="/crawl-history" className="text-blue-600 hover:underline">View history</Link>
-          </div>
-        </div>
-      )}
-
-      {/* Newest Properties */}
-      {(latestListings ?? []).length > 0 && (
-        <div className="bg-white rounded-lg border p-4">
-          <div className="flex items-center justify-between mb-3">
-            <h2 className="text-lg font-semibold text-gray-900">Newest Properties</h2>
-            <Link href="/listings?sort=newest" className="text-sm text-blue-600 hover:underline">View all</Link>
-          </div>
-          <div className="space-y-3">
-            {latestListings.map((listing: ListingItem) => (
-              <ListingRow key={listing.adId} listing={listing} />
-            ))}
-          </div>
-        </div>
-      )}
-    </div>
-  );
+function compactPrice(p: number | null | undefined): string {
+  if (p == null) return '—';
+  if (p >= 1_000_000) return `$${(p / 1_000_000).toFixed(2)}M`;
+  if (p >= 1_000) return `$${(p / 1_000).toFixed(0)}K`;
+  return `$${Math.round(p)}`;
 }
 
-/* ─── Market Tab ─────────────────────────────────────────────────────────── */
-
-function MarketTab() {
-  const { data, isLoading } = useQuery({
-    queryKey: ['dashboard', 'market'],
-    queryFn: () => fetch('/api/dashboard?tab=market').then(r => r.json()),
-  });
-
-  if (isLoading || !data) {
-    return (
-      <div className="animate-pulse space-y-4">
-        <div className="h-64 bg-gray-200 rounded-lg" />
-        <div className="h-64 bg-gray-200 rounded-lg" />
-      </div>
-    );
-  }
-
-  return (
-    <div className="space-y-6">
-      <LocationExplorer rows={data.locationBreakdown} />
-      <CategoryBreakdown rows={data.categoryBreakdown} />
-    </div>
-  );
-}
-
-/* ─── Searches Tab ───────────────────────────────────────────────────────── */
-
-function SearchesTab() {
-  const { data, isLoading } = useQuery<{ savedSearches: SavedSearchPreview[]; lastCrawlStart: string | null }>({
-    queryKey: ['dashboard', 'searches'],
-    queryFn: () => fetch('/api/dashboard?tab=searches').then(r => r.json()),
-  });
-
-  if (isLoading || !data) {
-    return <div className="animate-pulse h-64 bg-gray-200 rounded-lg" />;
-  }
-
-  const savedSearches = data.savedSearches ?? [];
-  const lastCrawlStart = data.lastCrawlStart ?? null;
-
-  if (savedSearches.length === 0) {
-    return (
-      <div className="bg-white rounded-lg border p-8 text-center">
-        <p className="text-gray-500">No saved searches yet.</p>
-        <p className="text-sm text-gray-400 mt-1">
-          Save a search from the{' '}
-          <Link href="/listings" className="text-blue-600 hover:underline">listings page</Link>
-          {' '}to track new matches.
-        </p>
-      </div>
-    );
-  }
-
-  return (
-    <div className="space-y-6">
-      {savedSearches.map((search) => (
-        <SavedSearchBox key={search.id} search={search} lastCrawlStart={lastCrawlStart} />
-      ))}
-    </div>
-  );
-}
-
-/* ─── Category Breakdown ──────────────────────────────────────────────────── */
-
-function CategoryBreakdown({ rows }: { rows: CategoryRow[] }) {
-  const [expandedCategories, setExpandedCategories] = useState<Set<string>>(new Set());
-
-  if (!rows || rows.length === 0) return null;
-
-  const grouped: Record<string, CategoryRow[]> = {};
-  for (const row of rows) {
-    if (!grouped[row.category]) grouped[row.category] = [];
-    grouped[row.category].push(row);
-  }
-
-  const toggleCategory = (cat: string) => {
-    setExpandedCategories(prev => {
-      const next = new Set(prev);
-      if (next.has(cat)) next.delete(cat);
-      else next.add(cat);
-      return next;
-    });
-  };
-
-  return (
-    <div className="bg-white rounded-lg border">
-      <div className="p-4 border-b">
-        <h2 className="text-lg font-semibold text-gray-900">Category Breakdown</h2>
-      </div>
-      <div className="divide-y">
-        {Object.entries(grouped).map(([category, subcategories]) => {
-          const isExpanded = expandedCategories.has(category);
-          const catTotal = subcategories.reduce((s, r) => s + r.active, 0);
-          const catNewWeek = subcategories.reduce((s, r) => s + r.newThisWeek, 0);
-          const prices = subcategories.filter(r => r.avgPrice != null).map(r => r.avgPrice!);
-          const catAvgPrice = prices.length > 0 ? prices.reduce((a, b) => a + b, 0) / prices.length : null;
-
-          return (
-            <div key={category}>
-              <button
-                onClick={() => toggleCategory(category)}
-                className="w-full flex items-center justify-between px-4 py-3 hover:bg-gray-50 transition-colors"
-              >
-                <div className="flex items-center gap-2">
-                  <svg className={`w-4 h-4 text-gray-400 transition-transform ${isExpanded ? 'rotate-90' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                  </svg>
-                  <span className="font-medium text-gray-900 capitalize">{category}</span>
-                  <span className="text-xs text-gray-400">{subcategories.length} subcategories</span>
-                </div>
-                <div className="flex items-center gap-4 text-sm">
-                  <span className="text-gray-600">{catTotal.toLocaleString()} active</span>
-                  <span className="text-gray-500">{formatCompactPrice(catAvgPrice)} avg</span>
-                  {catNewWeek > 0 && (
-                    <span className="text-xs font-medium bg-blue-50 text-blue-700 px-1.5 py-0.5 rounded">+{catNewWeek} this week</span>
-                  )}
-                </div>
-              </button>
-              {isExpanded && (
-                <div className="bg-gray-50 border-t">
-                  <table className="w-full text-sm">
-                    <thead>
-                      <tr className="text-xs text-gray-500 uppercase">
-                        <th className="text-left px-4 py-2 font-medium">Subcategory</th>
-                        <th className="text-right px-4 py-2 font-medium">Active</th>
-                        <th className="text-right px-4 py-2 font-medium">Avg Price</th>
-                        <th className="text-right px-4 py-2 font-medium hidden sm:table-cell">Min</th>
-                        <th className="text-right px-4 py-2 font-medium hidden sm:table-cell">Max</th>
-                        <th className="text-right px-4 py-2 font-medium">New</th>
-                      </tr>
-                    </thead>
-                    <tbody className="divide-y divide-gray-100">
-                      {subcategories.map(row => (
-                        <tr key={row.subcategory} className="hover:bg-gray-100 transition-colors">
-                          <td className="px-4 py-2">
-                            <Link href={`/listings?category=${encodeURIComponent(row.category)}&subcategory=${encodeURIComponent(row.subcategory)}`} className="text-blue-600 hover:underline capitalize">
-                              {row.subcategory.replace(/-/g, ' ')}
-                            </Link>
-                          </td>
-                          <td className="text-right px-4 py-2 text-gray-700">{row.active.toLocaleString()}</td>
-                          <td className="text-right px-4 py-2 text-gray-700">{formatCompactPrice(row.avgPrice)}</td>
-                          <td className="text-right px-4 py-2 text-gray-500 hidden sm:table-cell">{formatCompactPrice(row.minPrice)}</td>
-                          <td className="text-right px-4 py-2 text-gray-500 hidden sm:table-cell">{formatCompactPrice(row.maxPrice)}</td>
-                          <td className="text-right px-4 py-2">
-                            {row.newThisWeek > 0 ? <span className="text-blue-600 font-medium">+{row.newThisWeek}</span> : <span className="text-gray-400">0</span>}
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-              )}
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
-/* ─── Location Explorer ───────────────────────────────────────────────────── */
-
-interface CityData {
-  totalActive: number;
-  totalNew: number;
-  avgPrice: number | null;
-  locations: Record<string, LocationData>;
-}
-
-interface LocationData {
-  totalActive: number;
-  totalNew: number;
-  avgPrice: number | null;
-  categories: Array<{ category: string; subcategory: string; active: number; avgPrice: number | null; newThisWeek: number }>;
-}
-
-function LocationExplorer({ rows }: { rows: LocationRow[] }) {
-  const [expanded, setExpanded] = useState<Set<string>>(new Set());
-  const [showAllCities, setShowAllCities] = useState(false);
-
-  if (!rows || rows.length === 0) return null;
-
-  const cityMap: Record<string, CityData> = {};
-  for (const row of rows) {
-    if (!cityMap[row.city]) cityMap[row.city] = { totalActive: 0, totalNew: 0, avgPrice: null, locations: {} };
-    const city = cityMap[row.city];
-    city.totalActive += row.active;
-    city.totalNew += row.newThisWeek;
-    const locKey = row.location || '_other';
-    if (!city.locations[locKey]) city.locations[locKey] = { totalActive: 0, totalNew: 0, avgPrice: null, categories: [] };
-    const loc = city.locations[locKey];
-    loc.totalActive += row.active;
-    loc.totalNew += row.newThisWeek;
-    loc.categories.push({ category: row.category, subcategory: row.subcategory, active: row.active, avgPrice: row.avgPrice, newThisWeek: row.newThisWeek });
-  }
-
-  for (const city of Object.values(cityMap)) {
-    let wSum = 0, wTotal = 0;
-    for (const loc of Object.values(city.locations)) {
-      const priced = loc.categories.filter(c => c.avgPrice != null);
-      if (priced.length > 0) {
-        const ws = priced.reduce((s, c) => s + (c.avgPrice! * c.active), 0);
-        const ta = priced.reduce((s, c) => s + c.active, 0);
-        loc.avgPrice = ta > 0 ? ws / ta : null;
-        wSum += ws; wTotal += ta;
-      }
-    }
-    city.avgPrice = wTotal > 0 ? wSum / wTotal : null;
-  }
-
-  const sortedCities = Object.entries(cityMap).sort((a, b) => b[1].totalActive - a[1].totalActive);
-  const visibleCities = showAllCities ? sortedCities : sortedCities.slice(0, 10);
-
-  const toggle = (key: string) => {
-    setExpanded(prev => { const next = new Set(prev); if (next.has(key)) next.delete(key); else next.add(key); return next; });
-  };
-
-  return (
-    <div className="bg-white rounded-lg border">
-      <div className="p-4 border-b"><h2 className="text-lg font-semibold text-gray-900">Location Explorer</h2></div>
-      <div className="divide-y">
-        {visibleCities.map(([cityName, city]) => {
-          const cityExpanded = expanded.has(`c:${cityName}`);
-          const sortedLocations = Object.entries(city.locations).sort((a, b) => b[1].totalActive - a[1].totalActive);
-          return (
-            <div key={cityName}>
-              <button onClick={() => toggle(`c:${cityName}`)} className="w-full flex items-center justify-between px-4 py-3 hover:bg-gray-50 transition-colors">
-                <div className="flex items-center gap-2">
-                  <svg className={`w-4 h-4 text-gray-400 transition-transform ${cityExpanded ? 'rotate-90' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" /></svg>
-                  <Link href={`/listings?city=${encodeURIComponent(cityName)}`} onClick={e => e.stopPropagation()} className="font-medium text-gray-900 hover:text-blue-600">{cityName}</Link>
-                  <span className="text-xs text-gray-400">{sortedLocations.length} areas</span>
-                </div>
-                <div className="flex items-center gap-4 text-sm">
-                  <span className="text-gray-600">{city.totalActive.toLocaleString()} active</span>
-                  <span className="text-gray-500">{formatCompactPrice(city.avgPrice)} avg</span>
-                  {city.totalNew > 0 && <span className="text-xs font-medium bg-blue-50 text-blue-700 px-1.5 py-0.5 rounded">+{city.totalNew} this week</span>}
-                </div>
-              </button>
-              {cityExpanded && (() => {
-                const showAll = expanded.has(`showAll:${cityName}`);
-                const visible = showAll ? sortedLocations : sortedLocations.slice(0, 10);
-                const hidden = sortedLocations.length - 10;
-                return (
-                  <div className="border-t bg-gray-50">
-                    {visible.map(([locKey, loc]) => {
-                      const locName = locKey === '_other' ? 'Other' : locKey;
-                      const locExpanded = expanded.has(`l:${cityName}:${locKey}`);
-                      const sortedCats = [...loc.categories].sort((a, b) => b.active - a.active);
-                      return (
-                        <div key={locKey} className="border-b border-gray-100 last:border-b-0">
-                          <button onClick={() => toggle(`l:${cityName}:${locKey}`)} className="w-full flex items-center justify-between px-4 pl-10 py-2.5 hover:bg-gray-100 transition-colors">
-                            <div className="flex items-center gap-2">
-                              <svg className={`w-3.5 h-3.5 text-gray-400 transition-transform ${locExpanded ? 'rotate-90' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" /></svg>
-                              <Link href={`/listings?city=${encodeURIComponent(cityName)}&location=${encodeURIComponent(locKey === '_other' ? '' : locKey)}`} onClick={e => e.stopPropagation()} className="text-sm text-gray-800 hover:text-blue-600">{locName}</Link>
-                            </div>
-                            <div className="flex items-center gap-4 text-sm">
-                              <span className="text-gray-600">{loc.totalActive.toLocaleString()}</span>
-                              <span className="text-gray-500">{formatCompactPrice(loc.avgPrice)}</span>
-                              {loc.totalNew > 0 && <span className="text-xs text-blue-600 font-medium">+{loc.totalNew}</span>}
-                            </div>
-                          </button>
-                          {locExpanded && (
-                            <div className="bg-white border-t border-gray-100">
-                              <table className="w-full text-xs">
-                                <thead><tr className="text-gray-400 uppercase"><th className="text-left pl-16 pr-4 py-1.5 font-medium">Type</th><th className="text-right px-4 py-1.5 font-medium">Active</th><th className="text-right px-4 py-1.5 font-medium">Avg Price</th><th className="text-right px-4 py-1.5 font-medium">New</th></tr></thead>
-                                <tbody className="divide-y divide-gray-50">
-                                  {sortedCats.map(cat => (
-                                    <tr key={`${cat.category}-${cat.subcategory}`} className="hover:bg-gray-50">
-                                      <td className="pl-16 pr-4 py-1.5"><Link href={`/listings?city=${encodeURIComponent(cityName)}&location=${encodeURIComponent(locKey === '_other' ? '' : locKey)}&category=${encodeURIComponent(cat.category)}&subcategory=${encodeURIComponent(cat.subcategory)}`} className="text-blue-600 hover:underline capitalize">{cat.subcategory.replace(/-/g, ' ')}</Link><span className="text-gray-400 ml-1 capitalize">({cat.category})</span></td>
-                                      <td className="text-right px-4 py-1.5 text-gray-700">{cat.active}</td>
-                                      <td className="text-right px-4 py-1.5 text-gray-700">{formatCompactPrice(cat.avgPrice)}</td>
-                                      <td className="text-right px-4 py-1.5">{cat.newThisWeek > 0 ? <span className="text-blue-600 font-medium">+{cat.newThisWeek}</span> : <span className="text-gray-400">0</span>}</td>
-                                    </tr>
-                                  ))}
-                                </tbody>
-                              </table>
-                            </div>
-                          )}
-                        </div>
-                      );
-                    })}
-                    {!showAll && hidden > 0 && (
-                      <button onClick={() => toggle(`showAll:${cityName}`)} className="w-full py-2.5 pl-10 text-xs text-blue-600 hover:text-blue-800 hover:bg-gray-100 transition-colors text-left">Show {hidden} more areas</button>
-                    )}
-                  </div>
-                );
-              })()}
-            </div>
-          );
-        })}
-        {!showAllCities && sortedCities.length > 10 && (
-          <button onClick={() => setShowAllCities(true)} className="w-full py-3 text-sm text-blue-600 hover:text-blue-800 hover:bg-gray-50 transition-colors">Show {sortedCities.length - 10} more cities</button>
-        )}
-      </div>
-    </div>
-  );
-}
-
-/* ─── Saved Searches ──────────────────────────────────────────────────────── */
-
-function SavedSearchBox({ search, lastCrawlStart }: { search: SavedSearchPreview; lastCrawlStart: string | null }) {
-  const [expanded, setExpanded] = useState(false);
-  const searchListings = search.listings ?? [];
-  const newCount = lastCrawlStart ? searchListings.filter(l => l.firstSeenAt >= lastCrawlStart).length : 0;
-  const visible = expanded ? searchListings : searchListings.slice(0, 5);
-  const hasMore = searchListings.length > 5;
-  const params = getSearchParams(search.filters);
-
-  return (
-    <div className="bg-white rounded-lg border p-4">
-      <div className="flex items-center justify-between mb-3">
-        <div>
-          <h2 className="text-lg font-semibold text-gray-900">{search.name}</h2>
-          <p className="text-sm text-gray-500">{formatFilterSummary(search.filters)}</p>
-        </div>
-        <div className="flex items-center gap-3">
-          {newCount > 0 && <span className="text-xs font-medium bg-blue-100 text-blue-700 px-2 py-0.5 rounded-full">{newCount} new</span>}
-          <Link href={`/listings?${params.toString()}`} className="text-sm text-blue-600 hover:underline">View all</Link>
-        </div>
-      </div>
-      {searchListings.length === 0 ? (
-        <p className="text-gray-500 text-sm">No listings match this search.</p>
-      ) : (
-        <div className="space-y-3">
-          {visible.map(listing => <ListingRow key={listing.adId} listing={listing} isNew={!!lastCrawlStart && listing.firstSeenAt >= lastCrawlStart} />)}
-          {hasMore && !expanded && (
-            <button onClick={() => setExpanded(true)} className="w-full text-sm text-blue-600 hover:text-blue-800 py-2">Show {searchListings.length - 5} more</button>
-          )}
-        </div>
-      )}
-    </div>
-  );
+function formatDayLabel(iso: unknown): string {
+  if (typeof iso !== 'string') return '';
+  const d = new Date(iso);
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 }
 
 function getSearchParams(filtersJson: string): URLSearchParams {
   const params = new URLSearchParams();
-
   try {
     const filters = JSON.parse(filtersJson) as Record<string, unknown>;
     for (const [key, value] of Object.entries(filters)) {
@@ -500,61 +103,501 @@ function getSearchParams(filtersJson: string): URLSearchParams {
   } catch {
     return params;
   }
-
   return params;
 }
 
-function formatFilterSummary(filtersJson: string): string {
+function formatFilterSummary(filtersJson: string): Array<{ key: string; label: string }> {
   try {
-    const filters = JSON.parse(filtersJson) as Record<string, unknown>;
-    const parts: string[] = [];
-
-    if (typeof filters.q === 'string' && filters.q) parts.push(`"${filters.q}"`);
-    if (typeof filters.category === 'string' && filters.category) parts.push(filters.category);
-    if (typeof filters.subcategory === 'string' && filters.subcategory) parts.push(filters.subcategory);
-    if (filters.priceMin || filters.priceMax) parts.push(`$${filters.priceMin || '0'}-${filters.priceMax || '∞'}`);
-    if (filters.bedroomsMin) parts.push(`${filters.bedroomsMin}+ bd`);
-    if (typeof filters.location === 'string' && filters.location) parts.push(filters.location);
-    if (typeof filters.province === 'string' && filters.province) parts.push(filters.province);
-
-    return parts.join(' · ') || 'All listings';
+    const f = JSON.parse(filtersJson) as Record<string, unknown>;
+    const chips: Array<{ key: string; label: string }> = [];
+    if (typeof f.q === 'string' && f.q) chips.push({ key: 'q', label: `"${f.q}"` });
+    if (typeof f.category === 'string' && f.category) chips.push({ key: 'cat', label: f.category });
+    if (typeof f.subcategory === 'string' && f.subcategory) chips.push({ key: 'sub', label: f.subcategory.replace(/-/g, ' ') });
+    if (f.priceMin || f.priceMax) chips.push({ key: 'price', label: `$${f.priceMin || '0'}–$${f.priceMax || '∞'}` });
+    if (f.bedroomsMin) chips.push({ key: 'bd', label: `${f.bedroomsMin}+ bd` });
+    if (typeof f.location === 'string' && f.location) chips.push({ key: 'loc', label: f.location });
+    if (typeof f.city === 'string' && f.city) chips.push({ key: 'city', label: f.city });
+    return chips;
   } catch {
-    return 'All listings';
+    return [];
   }
 }
 
-/* ─── Shared Components ───────────────────────────────────────────────────── */
+export default function AuroraDashboard() {
+  useUser({ or: 'redirect' });
 
-function ListingRow({ listing, isNew }: { listing: ListingItem; isNew?: boolean }) {
+  const summary = useQuery<SummaryData>({
+    queryKey: ['dashboard', 'summary'],
+    queryFn: () => fetch('/api/dashboard?tab=summary').then((r) => r.json()),
+  });
+  const trends = useQuery<TrendsData>({
+    queryKey: ['dashboard', 'trends'],
+    queryFn: () => fetch('/api/dashboard/trends').then((r) => r.json()),
+  });
+  const searches = useQuery<SearchesData>({
+    queryKey: ['dashboard', 'searches'],
+    queryFn: () => fetch('/api/dashboard?tab=searches').then((r) => r.json()),
+  });
+
   return (
-    <Link href={`/listings/${listing.adId}`} className={`flex items-center gap-3 p-2 rounded hover:bg-gray-50 ${isNew ? 'bg-blue-50 border border-blue-200' : ''}`}>
-      {listing.thumbnail ? (
-        <img src={listing.thumbnail} alt="" className="w-12 h-12 rounded object-cover" />
-      ) : (
-        <div className="w-12 h-12 rounded bg-gray-100 flex items-center justify-center text-gray-400 text-xs">No img</div>
+    <div className="relative min-h-full">
+      <div className="px-8 py-10 max-w-[1400px] mx-auto">
+        <Header />
+
+        <section className="mt-10">
+          <Hero summary={summary.data} loading={summary.isLoading} />
+        </section>
+
+        {/* Saved searches — the most-used feature, given hero placement */}
+        <section className="mt-10">
+          <SavedSearchesBoard data={searches.data} loading={searches.isLoading} />
+        </section>
+
+        <section className="mt-10 grid grid-cols-1 lg:grid-cols-3 gap-6 items-stretch">
+          <div className="lg:col-span-2 h-full">
+            <TrendChart data={trends.data?.dailyTrend ?? []} loading={trends.isLoading} />
+          </div>
+          <div className="h-full">
+            <CategoryShare data={trends.data?.categoryShare ?? []} loading={trends.isLoading} />
+          </div>
+        </section>
+
+        <section className="mt-10 grid grid-cols-1 lg:grid-cols-3 gap-6 items-stretch">
+          <div className="lg:col-span-2 h-full">
+            <CityGrid cities={trends.data?.topCities ?? []} loading={trends.isLoading} />
+          </div>
+          <div className="h-full">
+            <FeaturedListings listings={summary.data?.latestListings ?? []} loading={summary.isLoading} />
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function Header() {
+  const today = new Date().toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' });
+  return (
+    <div className="flex flex-wrap items-end justify-between gap-4">
+      <div>
+        <p className="text-xs uppercase tracking-[0.3em] text-stone-500 font-medium">{today}</p>
+        <h1 className="mt-2 font-serif text-5xl md:text-6xl font-light tracking-tight text-stone-900 leading-[1.05]">
+          Good morning.<br />
+          <span className="italic text-stone-700">Here&rsquo;s your market.</span>
+        </h1>
+      </div>
+      <div className="flex items-center gap-2">
+        <Link href="/listings" className="aurora-pill aurora-pill-primary">
+          Browse listings →
+        </Link>
+        <Link href="/saved-searches" className="aurora-pill aurora-pill-ghost">
+          Manage searches
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function Hero({ summary, loading }: { summary: SummaryData | undefined; loading: boolean }) {
+  if (loading || !summary) {
+    return <div className="h-32 rounded-3xl aurora-surface animate-pulse" />;
+  }
+  const s = summary.stats;
+
+  const heroStats = [
+    { label: 'Active inventory', value: s.activeListings.toLocaleString(), accent: PALETTE.sageSoft },
+    { label: 'New this week', value: `+${s.newThisWeek.toLocaleString()}`, accent: PALETTE.sageSoft, badge: `+${s.newToday} today` },
+    { label: 'Avg sale price', value: compactPrice(s.avgPriceSale), accent: PALETTE.sandSoft },
+    { label: 'Avg rent price', value: compactPrice(s.avgPriceRent), accent: PALETTE.slateSoft },
+    { label: 'Active sellers', value: s.activeSellers.toLocaleString(), accent: PALETTE.sageSoft },
+  ];
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
+      {heroStats.map((h) => (
+        <div
+          key={h.label}
+          className="group relative overflow-hidden rounded-3xl aurora-surface p-6 transition-all hover:-translate-y-0.5 hover:shadow-lg"
+        >
+          <div
+            className="absolute -top-12 -right-12 h-28 w-28 rounded-full opacity-50 blur-2xl group-hover:opacity-80 transition-opacity"
+            style={{ background: h.accent }}
+          />
+          <div className="relative">
+            <p className="text-[10px] uppercase tracking-[0.2em] text-stone-500 font-medium">{h.label}</p>
+            <p className="mt-3 font-serif text-4xl font-light text-stone-900 tracking-tight tabular-nums">{h.value}</p>
+            {h.badge && (
+              <span className="mt-2 inline-block aurora-chip aurora-chip-mint">
+                {h.badge}
+              </span>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SavedSearchesBoard({ data, loading }: { data: SearchesData | undefined; loading: boolean }) {
+  const [active, setActive] = useState<number | null>(null);
+
+  if (loading) {
+    return <div className="h-72 rounded-3xl aurora-surface animate-pulse" />;
+  }
+
+  const searches = data?.savedSearches ?? [];
+  const lastCrawlStart = data?.lastCrawlStart ?? null;
+
+  if (searches.length === 0) {
+    return (
+      <div className="rounded-3xl aurora-surface p-8 text-center">
+        <div className="inline-flex items-center justify-center w-14 h-14 rounded-full mb-3"
+             style={{ background: 'linear-gradient(135deg, #ecf3ec, #ebe4cd)' }}>
+          <svg className="w-6 h-6 text-stone-700" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-4-7 4V5z" />
+          </svg>
+        </div>
+        <p className="font-serif text-2xl text-stone-900">No saved searches yet</p>
+        <p className="text-sm text-stone-500 mt-1">
+          Save a filter from the{' '}
+          <Link href="/listings" className="text-stone-900 underline-offset-4 hover:underline">browse page</Link>{' '}
+          to track new matches here.
+        </p>
+      </div>
+    );
+  }
+
+  // Default to the search with the most new since last crawl
+  const enrichedSearches = searches.map((s) => {
+    const newCount = lastCrawlStart
+      ? s.listings.filter((l) => l.firstSeenAt >= lastCrawlStart).length
+      : 0;
+    return { ...s, newCount };
+  });
+  const activeId = active ?? enrichedSearches[0]?.id ?? null;
+  const activeSearch = enrichedSearches.find((s) => s.id === activeId) ?? enrichedSearches[0];
+  const activeChips = activeSearch ? formatFilterSummary(activeSearch.filters) : [];
+  const activeListings = activeSearch?.listings ?? [];
+  const activeListingsVisible = activeListings.slice(0, 6);
+
+  return (
+    <div className="rounded-3xl aurora-surface overflow-hidden">
+      <div className="px-6 py-5 flex flex-wrap items-center justify-between gap-3 border-b border-stone-200/60">
+        <div>
+          <p className="text-[11px] uppercase tracking-[0.3em] text-stone-500 font-medium">Watching</p>
+          <h2 className="font-serif text-2xl text-stone-900 mt-1">
+            <span className="aurora-rule">Latest from your saved searches</span>
+          </h2>
+        </div>
+        <Link href="/saved-searches" className="aurora-pill aurora-pill-ghost">
+          Manage all →
+        </Link>
+      </div>
+
+      {/* Search tabs */}
+      <div className="px-6 pt-4 pb-2 flex flex-wrap gap-2">
+        {enrichedSearches.map((s) => {
+          const isActive = s.id === activeId;
+          return (
+            <button
+              key={s.id}
+              onClick={() => setActive(s.id)}
+              className={`aurora-pill ${isActive ? 'aurora-pill-primary' : 'aurora-pill-ghost'}`}
+            >
+              <span className="truncate max-w-[160px]">{s.name}</span>
+              {s.newCount > 0 && (
+                <span
+                  className={`ml-1 px-1.5 py-0.5 rounded-full text-[10px] tabular-nums ${
+                    isActive ? 'bg-white/20 text-white' : 'bg-emerald-100 text-emerald-700'
+                  }`}
+                >
+                  +{s.newCount}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {activeSearch && (
+        <div className="px-6 pt-2 pb-6">
+          <div className="flex flex-wrap items-center gap-2 mb-4">
+            {activeChips.map((c) => (
+              <span key={c.key} className="aurora-chip capitalize">{c.label}</span>
+            ))}
+            {activeChips.length === 0 && <span className="aurora-chip">All listings</span>}
+            <Link
+              href={`/listings?${getSearchParams(activeSearch.filters).toString()}`}
+              className="ml-auto text-sm text-stone-600 hover:text-stone-900 underline-offset-4 hover:underline"
+            >
+              View {activeListings.length}+ matches →
+            </Link>
+          </div>
+
+          {activeListingsVisible.length === 0 ? (
+            <p className="text-sm text-stone-500 py-8 text-center italic">No listings match this search yet.</p>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+              {activeListingsVisible.map((listing) => {
+                const isNew = !!lastCrawlStart && listing.firstSeenAt >= lastCrawlStart;
+                return <SavedSearchListingCard key={listing.adId} listing={listing} isNew={isNew} />;
+              })}
+            </div>
+          )}
+        </div>
       )}
+    </div>
+  );
+}
+
+function SavedSearchListingCard({ listing, isNew }: { listing: ListingItem; isNew: boolean }) {
+  return (
+    <Link
+      href={`/listings/${listing.adId}`}
+      className={`group flex gap-3 p-3 rounded-2xl transition-all border ${
+        isNew
+          ? 'border-emerald-200 bg-emerald-50/40 hover:bg-emerald-50/60'
+          : 'border-transparent hover:bg-white/60'
+      }`}
+    >
+      <div className="relative w-20 h-20 rounded-xl overflow-hidden bg-stone-100 flex-shrink-0">
+        {listing.thumbnail ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={listing.thumbnail} alt="" className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500" />
+        ) : (
+          <div className="w-full h-full bg-gradient-to-br from-stone-100 to-stone-200" />
+        )}
+        {isNew && (
+          <span className="absolute top-1 left-1 aurora-chip aurora-chip-mint text-[9px] px-1.5 py-0">
+            New
+          </span>
+        )}
+      </div>
       <div className="flex-1 min-w-0">
-        <p className="text-sm font-medium text-gray-900 truncate">{listing.title || listing.adId}</p>
-        <p className="text-xs text-gray-500">{listing.location}</p>
-      </div>
-      <div className="hidden sm:flex items-center gap-3 text-xs text-gray-500">
-        {listing.bedrooms != null && <span>{listing.bedrooms} bd</span>}
-        {listing.bathrooms != null && <span>{listing.bathrooms} ba</span>}
-        {listing.builtAreaSqm != null && <span>{formatArea(listing.builtAreaSqm)}</span>}
-      </div>
-      <div className="text-right">
-        <p className="text-sm font-medium text-gray-900">{listing.price ? formatPrice(listing.price) : '—'}</p>
-        <p className="text-xs text-gray-400">{formatRelativeDate(listing.firstSeenAt)}</p>
+        <p className="font-serif text-lg text-stone-900 leading-tight">
+          {listing.price ? compactPrice(listing.price) : '—'}
+        </p>
+        <p className="text-xs text-stone-700 truncate mt-0.5">{listing.title || listing.adId}</p>
+        <p className="text-[11px] text-stone-500 truncate">{listing.location || '—'}</p>
+        <div className="flex items-center gap-2 mt-1.5 text-[10px] text-stone-500">
+          {listing.bedrooms != null && <span>{listing.bedrooms}bd</span>}
+          {listing.bathrooms != null && <span>{listing.bathrooms}ba</span>}
+          {listing.builtAreaSqm != null && <span>{Math.round(listing.builtAreaSqm)}m²</span>}
+          <span className="ml-auto text-stone-400">{formatRelativeDate(listing.firstSeenAt)}</span>
+        </div>
       </div>
     </Link>
   );
 }
 
-function StatCard({ label, value, accent }: { label: string; value: string; accent?: boolean }) {
+function TrendChart({ data, loading }: { data: TrendsData['dailyTrend']; loading: boolean }) {
+  if (loading) {
+    return <div className="h-80 lg:h-full min-h-[20rem] rounded-3xl aurora-surface animate-pulse" />;
+  }
+
+  const total = data.reduce((s, d) => s + d.added, 0);
+  const recent7 = data.slice(-7).reduce((s, d) => s + d.added, 0);
+  const prior7 = data.slice(-14, -7).reduce((s, d) => s + d.added, 0);
+  const wow = prior7 > 0 ? Math.round(((recent7 - prior7) / prior7) * 100) : 0;
+
   return (
-    <div className="bg-white rounded-lg border p-4">
-      <p className="text-sm text-gray-500">{label}</p>
-      <p className={`text-2xl font-bold mt-1 ${accent ? 'text-blue-600' : 'text-gray-900'}`}>{value}</p>
+    <div className="rounded-3xl aurora-surface p-6 h-full flex flex-col">
+      <div className="flex items-start justify-between mb-6">
+        <div>
+          <h2 className="font-serif text-2xl text-stone-900">
+            <span className="aurora-rule">Inventory flow</span>
+          </h2>
+          <p className="text-sm text-stone-500 mt-1">New listings discovered over the last 30 days</p>
+        </div>
+        <div className="text-right">
+          <p className="font-serif text-3xl text-stone-900 tabular-nums">{total.toLocaleString()}</p>
+          <p className={`text-xs font-medium mt-0.5 ${wow >= 0 ? 'text-emerald-700' : 'text-rose-700'}`}>
+            {wow >= 0 ? '↑' : '↓'} {Math.abs(wow)}% week over week
+          </p>
+        </div>
+      </div>
+      <div className="flex-1 min-h-[240px]">
+      <ResponsiveContainer width="100%" height="100%">
+        <AreaChart data={data} margin={{ top: 10, right: 10, left: -20, bottom: 0 }}>
+          <defs>
+            <linearGradient id="aurora-added" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor={PALETTE.sage} stopOpacity={0.55} />
+              <stop offset="100%" stopColor={PALETTE.sage} stopOpacity={0} />
+            </linearGradient>
+            <linearGradient id="aurora-removed" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stopColor={PALETTE.sand} stopOpacity={0.5} />
+              <stop offset="100%" stopColor={PALETTE.sand} stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <CartesianGrid strokeDasharray="3 3" stroke="#e7e5e4" vertical={false} />
+          <XAxis dataKey="day" tickFormatter={formatDayLabel} stroke="#a8a29e" fontSize={11} tickLine={false} axisLine={false} />
+          <YAxis stroke="#a8a29e" fontSize={11} tickLine={false} axisLine={false} />
+          <Tooltip
+            contentStyle={{ background: 'rgba(255,255,255,0.97)', border: '1px solid #e7e5e4', borderRadius: 12, fontSize: 12 }}
+            labelFormatter={formatDayLabel}
+          />
+          <Area type="monotone" dataKey="removed" stroke={PALETTE.sand} strokeWidth={2} fill="url(#aurora-removed)" />
+          <Area type="monotone" dataKey="added" stroke={PALETTE.sageDeep} strokeWidth={2.5} fill="url(#aurora-added)" />
+        </AreaChart>
+      </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}
+
+function CategoryShare({ data, loading }: { data: TrendsData['categoryShare']; loading: boolean }) {
+  if (loading) {
+    return <div className="h-80 lg:h-full min-h-[20rem] rounded-3xl aurora-surface animate-pulse" />;
+  }
+
+  const COLORS = [PALETTE.sageDeep, PALETTE.sand, PALETTE.slate, PALETTE.sageSoft];
+  const total = data.reduce((s, d) => s + d.active, 0);
+
+  return (
+    <div className="rounded-3xl aurora-surface p-6 h-full flex flex-col">
+      <div>
+        <h2 className="font-serif text-2xl text-stone-900">
+          <span className="aurora-rule">Category mix</span>
+        </h2>
+        <p className="text-sm text-stone-500 mt-1">Active inventory split</p>
+      </div>
+      <div className="flex-1 flex items-center justify-center min-h-[180px] py-3">
+        <ResponsiveContainer width="100%" height="100%" minHeight={180}>
+          <PieChart margin={{ top: 4, right: 4, bottom: 4, left: 4 }}>
+            <Pie
+              data={data}
+              dataKey="active"
+              nameKey="category"
+              cx="50%"
+              cy="50%"
+              innerRadius="55%"
+              outerRadius="85%"
+              paddingAngle={3}
+            >
+              {data.map((_, i) => (
+                <Cell key={i} fill={COLORS[i % COLORS.length]} stroke="none" />
+              ))}
+            </Pie>
+          </PieChart>
+        </ResponsiveContainer>
+      </div>
+      <div className="space-y-2">
+        {data.map((d, i) => (
+          <div key={d.category} className="flex items-center justify-between text-sm">
+            <span className="flex items-center gap-2 capitalize text-stone-700">
+              <span className="w-2.5 h-2.5 rounded-full" style={{ background: COLORS[i % COLORS.length] }} />
+              {d.category.replace('_', ' ')}
+            </span>
+            <span className="text-stone-500 tabular-nums">
+              {((d.active / total) * 100).toFixed(0)}%
+              <span className="text-stone-400 ml-2">{d.active.toLocaleString()}</span>
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function FeaturedListings({ listings, loading }: { listings: ListingItem[]; loading: boolean }) {
+  if (loading) {
+    return <div className="h-96 rounded-3xl aurora-surface animate-pulse" />;
+  }
+
+  const featured = listings.slice(0, 5);
+
+  return (
+    <div className="rounded-3xl aurora-surface p-6">
+      <div className="flex items-center justify-between mb-4">
+        <div>
+          <h2 className="font-serif text-2xl text-stone-900">
+            <span className="aurora-rule">Newest</span>
+          </h2>
+          <p className="text-xs text-stone-500 mt-1">Across the whole market</p>
+        </div>
+        <Link href="/listings?sort=newest" className="text-sm text-stone-600 hover:text-stone-900 underline-offset-4 hover:underline">
+          See all →
+        </Link>
+      </div>
+      <div className="space-y-2">
+        {featured.map((l) => (
+          <Link
+            key={l.adId}
+            href={`/listings/${l.adId}`}
+            className="group flex gap-3 p-2 rounded-2xl hover:bg-white/60 transition-all"
+          >
+            <div className="relative w-16 h-16 rounded-xl overflow-hidden flex-shrink-0 bg-stone-100">
+              {l.thumbnail ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img src={l.thumbnail} alt="" className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500" />
+              ) : (
+                <div className="w-full h-full bg-gradient-to-br from-stone-100 to-stone-200" />
+              )}
+            </div>
+            <div className="flex-1 min-w-0">
+              <p className="font-serif text-base text-stone-900 leading-tight">{compactPrice(l.price)}</p>
+              <p className="text-xs text-stone-700 truncate">{l.title || l.adId}</p>
+              <p className="text-[11px] text-stone-500 truncate">{l.location || '—'}</p>
+              <p className="text-[10px] text-stone-400 mt-0.5">{formatRelativeDate(l.firstSeenAt)}</p>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function CityGrid({ cities, loading }: { cities: TrendsData['topCities']; loading: boolean }) {
+  const max = useMemo(() => Math.max(1, ...cities.map((c) => c.active)), [cities]);
+
+  if (loading) {
+    return <div className="h-64 rounded-3xl aurora-surface animate-pulse" />;
+  }
+
+  return (
+    <div className="rounded-3xl aurora-surface p-6">
+      <div className="flex items-center justify-between mb-5">
+        <div>
+          <h2 className="font-serif text-2xl text-stone-900">
+            <span className="aurora-rule">Cities at a glance</span>
+          </h2>
+          <p className="text-sm text-stone-500 mt-1">Where the inventory lives</p>
+        </div>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        {cities.map((c) => {
+          const pct = (c.active / max) * 100;
+          return (
+            <Link
+              key={c.city}
+              href={`/listings?city=${encodeURIComponent(c.city)}`}
+              className="group p-4 rounded-2xl bg-white/55 hover:bg-white border border-stone-200/60 hover:shadow-md transition-all"
+            >
+              <div className="flex items-start justify-between">
+                <p className="font-serif text-lg text-stone-900 group-hover:text-stone-700">{c.city}</p>
+                {c.newThisWeek > 0 && (
+                  <span className="aurora-chip aurora-chip-mint">+{c.newThisWeek}</span>
+                )}
+              </div>
+              <p className="text-2xl font-serif text-stone-900 mt-1.5 tabular-nums">{c.active.toLocaleString()}</p>
+              <p className="text-[11px] text-stone-500 uppercase tracking-wider">active</p>
+              <div className="mt-2.5 h-1 rounded-full bg-stone-100 overflow-hidden">
+                <div
+                  className="h-full transition-all"
+                  style={{
+                    width: `${pct}%`,
+                    background: 'linear-gradient(to right, #6b8e6b, #c9b896)',
+                  }}
+                />
+              </div>
+              <div className="mt-3 flex justify-between text-[11px] text-stone-500">
+                <span>Sale {compactPrice(c.avgSale)}</span>
+                <span>Rent {compactPrice(c.avgRent)}</span>
+              </div>
+            </Link>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/web/src/app/(app)/pipeline/page.tsx
+++ b/web/src/app/(app)/pipeline/page.tsx
@@ -2,7 +2,7 @@
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useUser } from '@stackframe/stack';
-import { PIPELINE_STAGES, PIPELINE_STAGE_LABELS } from '@/lib/constants';
+import { PIPELINE_STAGES, PIPELINE_STAGE_LABELS, type PipelineStage } from '@/lib/constants';
 import { formatPrice } from '@/lib/formatters';
 import Link from 'next/link';
 import {
@@ -38,6 +38,26 @@ interface PipelineItem {
   url: string | null;
 }
 
+const STAGE_GRADIENTS: Record<PipelineStage, string> = {
+  discovered: 'from-stone-200 to-stone-300',
+  shortlisted: 'from-emerald-100 to-emerald-200',
+  contacted: 'from-amber-100 to-amber-200',
+  visited: 'from-stone-200 to-amber-100',
+  negotiating: 'from-emerald-200 to-stone-300',
+  won: 'from-emerald-300 to-stone-700',
+  passed: 'from-stone-300 to-stone-500',
+};
+
+const STAGE_DOT: Record<PipelineStage, string> = {
+  discovered: '#a8a29e',
+  shortlisted: '#84a982',
+  contacted: '#c9b896',
+  visited: '#94a3b8',
+  negotiating: '#6b8e6b',
+  won: '#1a1a1a',
+  passed: '#78716c',
+};
+
 function KanbanCard({ item }: { item: PipelineItem }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: item.adId,
@@ -47,7 +67,7 @@ function KanbanCard({ item }: { item: PipelineItem }) {
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
-    opacity: isDragging ? 0.5 : 1,
+    opacity: isDragging ? 0.4 : 1,
   };
 
   return (
@@ -56,51 +76,80 @@ function KanbanCard({ item }: { item: PipelineItem }) {
       style={style}
       {...attributes}
       {...listeners}
-      className="bg-white border rounded-lg p-2 cursor-grab active:cursor-grabbing hover:shadow-sm"
+      className="aurora-surface rounded-2xl p-2.5 cursor-grab active:cursor-grabbing hover:shadow-lg transition-shadow"
     >
-      {item.thumbnail && (
-        <img src={item.thumbnail} alt="" className="w-full h-20 object-cover rounded mb-1.5" />
+      {item.thumbnail ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={item.thumbnail} alt="" className="w-full h-24 object-cover rounded-xl mb-2" />
+      ) : (
+        <div className="w-full h-24 rounded-xl mb-2 bg-gradient-to-br from-stone-100 to-stone-200" />
       )}
-      <p className="text-sm font-bold text-gray-900">{formatPrice(item.price, item.currency || 'USD')}</p>
-      <p className="text-xs text-gray-700 truncate">{item.title}</p>
-      <p className="text-xs text-gray-400 truncate">{item.location}</p>
-      <div className="flex gap-2 text-xs text-gray-500 mt-1">
-        {item.bedrooms != null && <span>{item.bedrooms}bd</span>}
-        {item.bathrooms != null && <span>{item.bathrooms}ba</span>}
+      <p className="font-serif text-base text-stone-900">{formatPrice(item.price, item.currency || 'USD')}</p>
+      <p className="text-xs text-stone-700 truncate mt-0.5">{item.title || '—'}</p>
+      <p className="text-[10px] text-stone-500 truncate">{item.location || '—'}</p>
+      <div className="flex items-center justify-between mt-2">
+        <div className="flex gap-2 text-[10px] text-stone-500">
+          {item.bedrooms != null && <span>{item.bedrooms}bd</span>}
+          {item.bathrooms != null && <span>{item.bathrooms}ba</span>}
+          {item.builtAreaSqm != null && <span>{Math.round(item.builtAreaSqm)}m²</span>}
+        </div>
+        <Link
+          href={`/listings/${item.adId}`}
+          className="text-[11px] text-stone-600 hover:text-stone-900 underline-offset-2 hover:underline"
+          onClick={e => e.stopPropagation()}
+        >
+          View →
+        </Link>
       </div>
-      <Link
-        href={`/listings/${item.adId}`}
-        className="text-xs text-blue-600 hover:underline mt-1 block"
-        onClick={e => e.stopPropagation()}
-      >
-        Details
-      </Link>
     </div>
   );
 }
 
-function KanbanColumn({ stage, items }: { stage: string; items: PipelineItem[] }) {
+function KanbanColumn({ stage, items }: { stage: PipelineStage; items: PipelineItem[] }) {
   const { setNodeRef, isOver } = useDroppable({ id: stage });
 
   return (
-    <div className="flex flex-col w-64 shrink-0">
-      <div className="flex items-center justify-between px-2 py-1.5 mb-2">
-        <h3 className="text-sm font-semibold text-gray-700">
-          {PIPELINE_STAGE_LABELS[stage as keyof typeof PIPELINE_STAGE_LABELS] ?? stage}
-        </h3>
-        <span className="text-xs bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded-full">{items.length}</span>
+    <div className="flex flex-col w-72 shrink-0">
+      <div className="flex items-center justify-between px-3 mb-2.5">
+        <div className="flex items-center gap-2">
+          <span className="w-2 h-2 rounded-full" style={{ background: STAGE_DOT[stage] }} />
+          <h3 className="font-serif text-base text-stone-900">
+            {PIPELINE_STAGE_LABELS[stage]}
+          </h3>
+        </div>
+        <span
+          className="text-[11px] font-medium px-2 py-0.5 rounded-full bg-white/70 text-stone-600 tabular-nums"
+        >
+          {items.length}
+        </span>
       </div>
+
       <div
         ref={setNodeRef}
-        className={`flex-1 space-y-2 p-2 rounded-lg min-h-[200px] transition-colors ${
-          isOver ? 'bg-blue-50 border-2 border-blue-200' : 'bg-gray-50 border-2 border-transparent'
-        }`}
+        className={`relative flex-1 rounded-2xl min-h-[400px] transition-all overflow-hidden
+          ${isOver ? 'ring-2 ring-emerald-700/50 ring-offset-2 ring-offset-transparent' : ''}
+        `}
+        style={{
+          background: 'rgba(255,255,255,0.35)',
+          backdropFilter: 'blur(8px)',
+          border: '1px solid rgba(255,255,255,0.7)',
+        }}
       >
-        <SortableContext items={items.map(i => i.adId)} strategy={verticalListSortingStrategy}>
-          {items.map(item => (
-            <KanbanCard key={item.adId} item={item} />
-          ))}
-        </SortableContext>
+        <div
+          className={`absolute -top-12 -left-12 w-32 h-32 rounded-full bg-gradient-to-br ${STAGE_GRADIENTS[stage]} opacity-40 blur-2xl`}
+        />
+        <div className="relative p-2.5 space-y-2.5">
+          <SortableContext items={items.map(i => i.adId)} strategy={verticalListSortingStrategy}>
+            {items.map(item => (
+              <KanbanCard key={item.adId} item={item} />
+            ))}
+          </SortableContext>
+          {items.length === 0 && (
+            <div className="text-center py-8 text-xs text-stone-400 italic">
+              Drop here
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );
@@ -173,28 +222,66 @@ export default function PipelinePage() {
   const grouped = PIPELINE_STAGES.reduce((acc, stage) => {
     acc[stage] = items.filter(i => i.stage === stage);
     return acc;
-  }, {} as Record<string, PipelineItem[]>);
+  }, {} as Record<PipelineStage, PipelineItem[]>);
 
-  if (isLoading) {
-    return (
-      <div className="p-6">
-        <h1 className="text-2xl font-bold text-gray-900 mb-4">Pipeline</h1>
-        <div className="animate-pulse flex gap-4">
-          {[...Array(4)].map((_, i) => (
-            <div key={i} className="w-64 h-64 bg-gray-200 rounded-lg" />
-          ))}
-        </div>
-      </div>
-    );
-  }
+  const totalValue = items
+    .filter(i => i.price != null && i.stage !== 'passed')
+    .reduce((s, i) => s + (i.price || 0), 0);
 
   return (
-    <div className="p-6">
-      <h1 className="text-2xl font-bold text-gray-900 mb-4">Pipeline</h1>
-      {items.length === 0 ? (
-        <div className="text-center py-12">
-          <p className="text-gray-500">No properties in the pipeline yet.</p>
-          <p className="text-sm text-gray-400 mt-1">Add properties from the listing detail page.</p>
+    <div className="px-6 md:px-10 py-8 max-w-[1700px] mx-auto">
+      {/* Hero */}
+      <div className="flex flex-wrap items-end justify-between gap-4 mb-8">
+        <div>
+          <p className="text-[11px] uppercase tracking-[0.3em] text-stone-500 font-medium">
+            Workflow
+          </p>
+          <h1 className="font-serif text-4xl md:text-5xl font-light tracking-tight text-stone-900 mt-1.5">
+            Pipeline
+          </h1>
+          <p className="text-sm text-stone-500 mt-2">
+            Drag properties through the stages — from discovery to deal.
+          </p>
+        </div>
+        {items.length > 0 && (
+          <div className="aurora-surface rounded-2xl px-5 py-3 flex items-center gap-6">
+            <div>
+              <p className="text-[10px] uppercase tracking-wider text-stone-500 font-medium">In flow</p>
+              <p className="font-serif text-2xl text-stone-900 tabular-nums">{items.length}</p>
+            </div>
+            <div className="w-px h-9 bg-stone-200" />
+            <div>
+              <p className="text-[10px] uppercase tracking-wider text-stone-500 font-medium">Pipeline value</p>
+              <p className="font-serif text-2xl text-stone-900 tabular-nums">
+                ${totalValue >= 1_000_000 ? `${(totalValue / 1_000_000).toFixed(1)}M` : totalValue >= 1_000 ? `${(totalValue / 1_000).toFixed(0)}K` : totalValue.toLocaleString()}
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {isLoading ? (
+        <div className="flex gap-4">
+          {[...Array(5)].map((_, i) => (
+            <div key={i} className="w-72 h-96 rounded-2xl aurora-surface animate-pulse" />
+          ))}
+        </div>
+      ) : items.length === 0 ? (
+        <div className="text-center py-16 rounded-3xl aurora-surface">
+          <div
+            className="inline-flex items-center justify-center w-16 h-16 rounded-full mb-4"
+            style={{ background: 'linear-gradient(135deg, #ecf3ec, #ebe4cd)' }}
+          >
+            <svg className="w-7 h-7 text-stone-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M3 7h18M3 12h12M3 17h6" />
+            </svg>
+          </div>
+          <p className="font-serif text-2xl text-stone-900">Nothing in your pipeline yet</p>
+          <p className="text-sm text-stone-500 mt-1">
+            Add a property from the{' '}
+            <Link href="/listings" className="text-stone-800 underline-offset-4 hover:underline">listing detail page</Link>{' '}
+            to get started.
+          </p>
         </div>
       ) : (
         <DndContext
@@ -203,16 +290,16 @@ export default function PipelinePage() {
           onDragStart={handleDragStart}
           onDragEnd={handleDragEnd}
         >
-          <div className="flex gap-4 overflow-x-auto pb-4">
+          <div className="flex gap-4 overflow-x-auto pb-6 -mx-2 px-2">
             {PIPELINE_STAGES.map(stage => (
               <KanbanColumn key={stage} stage={stage} items={grouped[stage] || []} />
             ))}
           </div>
           <DragOverlay>
             {activeItem && (
-              <div className="bg-white border rounded-lg p-2 shadow-lg w-64 opacity-90">
-                <p className="text-sm font-bold">{formatPrice(activeItem.price)}</p>
-                <p className="text-xs truncate">{activeItem.title}</p>
+              <div className="aurora-surface rounded-2xl p-2.5 w-72 shadow-2xl rotate-2">
+                <p className="font-serif text-base text-stone-900">{formatPrice(activeItem.price)}</p>
+                <p className="text-xs text-stone-700 truncate">{activeItem.title}</p>
               </div>
             )}
           </DragOverlay>

--- a/web/src/app/(app)/saved-searches/page.tsx
+++ b/web/src/app/(app)/saved-searches/page.tsx
@@ -102,14 +102,6 @@ export default function SavedSearchesPage() {
     },
   });
 
-  const refreshMutation = useMutation({
-    mutationFn: () => fetch('/api/saved-searches/check-all', { method: 'POST' }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['saved-searches'] });
-      queryClient.invalidateQueries({ queryKey: ['dashboard', 'searches'] });
-    },
-  });
-
   function applySearch(filtersJson: string) {
     const params = getSearchParams(filtersJson);
     router.push(`/listings?${params.toString()}`);
@@ -126,35 +118,23 @@ export default function SavedSearchesPage() {
   return (
     <div className="px-6 md:px-10 py-8 max-w-[1300px] mx-auto">
       {/* Hero */}
-      <div className="flex flex-wrap items-end justify-between gap-4 mb-8">
-        <div>
-          <p className="text-[11px] uppercase tracking-[0.3em] text-stone-500 font-medium">Watching</p>
-          <h1 className="font-serif text-4xl md:text-5xl font-light tracking-tight text-stone-900 mt-1.5">
-            Saved <span className="italic">searches</span>
-          </h1>
-          <p className="text-sm text-stone-500 mt-2">
-            {isLoading ? 'Loading…' : searches.length === 0
-              ? 'Save filters from the browse page to follow new matches.'
-              : (
-                <>
-                  {searches.length} active {searches.length === 1 ? 'search' : 'searches'}
-                  {totalNew > 0 && (
-                    <span className="ml-2 aurora-chip aurora-chip-mint">+{totalNew} new since last check</span>
-                  )}
-                </>
-              )}
-          </p>
-        </div>
-        <button
-          onClick={() => refreshMutation.mutate()}
-          disabled={refreshMutation.isPending || searches.length === 0}
-          className="aurora-pill aurora-pill-primary disabled:opacity-40 disabled:cursor-not-allowed"
-        >
-          <svg className={`w-3.5 h-3.5 ${refreshMutation.isPending ? 'animate-spin' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h5M20 20v-5h-5M5 9a8 8 0 0114-3M19 15a8 8 0 01-14 3" />
-          </svg>
-          {refreshMutation.isPending ? 'Checking…' : 'Check for new'}
-        </button>
+      <div className="mb-8">
+        <p className="text-[11px] uppercase tracking-[0.3em] text-stone-500 font-medium">Watching</p>
+        <h1 className="font-serif text-4xl md:text-5xl font-light tracking-tight text-stone-900 mt-1.5">
+          Saved <span className="italic">searches</span>
+        </h1>
+        <p className="text-sm text-stone-500 mt-2">
+          {isLoading ? 'Loading…' : searches.length === 0
+            ? 'Save filters from the browse page to follow new matches.'
+            : (
+              <>
+                {searches.length} active {searches.length === 1 ? 'search' : 'searches'}
+                {totalNew > 0 && (
+                  <span className="ml-2 aurora-chip aurora-chip-mint">+{totalNew} new since last check</span>
+                )}
+              </>
+            )}
+        </p>
       </div>
 
       {isLoading ? (
@@ -200,10 +180,7 @@ export default function SavedSearchesPage() {
                     <div className="flex items-center gap-2 flex-wrap">
                       <h2 className="font-serif text-2xl text-stone-900">{search.name}</h2>
                       {newSinceCrawl > 0 && (
-                        <span
-                          className="aurora-chip text-white"
-                          style={{ background: 'linear-gradient(135deg, #4a6b4a, #1a1a1a)', borderColor: 'transparent' }}
-                        >
+                        <span className="aurora-chip aurora-chip-ink">
                           +{newSinceCrawl} new
                         </span>
                       )}

--- a/web/src/app/(app)/saved-searches/page.tsx
+++ b/web/src/app/(app)/saved-searches/page.tsx
@@ -4,9 +4,9 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useUser } from '@stackframe/stack';
 import { formatRelativeDate } from '@/lib/formatters';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import Link from 'next/link';
 
-interface SavedSearch {
+interface SavedSearchMeta {
   id: number;
   name: string;
   filters: string;
@@ -16,124 +16,296 @@ interface SavedSearch {
   updatedAt: string;
 }
 
+interface ListingItem {
+  adId: string;
+  title: string | null;
+  price: number | null;
+  location: string | null;
+  bedrooms: number | null;
+  bathrooms: number | null;
+  builtAreaSqm: number | null;
+  thumbnail: string | null;
+  firstSeenAt: string;
+}
+
+interface SavedSearchPreview {
+  id: number;
+  name: string;
+  filters: string;
+  listings: ListingItem[];
+}
+
+interface DashboardSearchesData {
+  savedSearches: SavedSearchPreview[];
+  lastCrawlStart: string | null;
+}
+
+function compactPrice(p: number | null | undefined): string {
+  if (p == null) return '—';
+  if (p >= 1_000_000) return `$${(p / 1_000_000).toFixed(2)}M`;
+  if (p >= 1_000) return `$${(p / 1_000).toFixed(0)}K`;
+  return `$${Math.round(p)}`;
+}
+
+function getSearchParams(filtersJson: string): URLSearchParams {
+  const params = new URLSearchParams();
+  try {
+    const filters = JSON.parse(filtersJson) as Record<string, unknown>;
+    for (const [key, value] of Object.entries(filters)) {
+      if (value != null && value !== '') params.set(key, String(value));
+    }
+  } catch {
+    return params;
+  }
+  return params;
+}
+
+function filterChips(filtersJson: string): Array<{ key: string; label: string }> {
+  try {
+    const f = JSON.parse(filtersJson) as Record<string, unknown>;
+    const chips: Array<{ key: string; label: string }> = [];
+    if (typeof f.q === 'string' && f.q) chips.push({ key: 'q', label: `"${f.q}"` });
+    if (typeof f.category === 'string' && f.category) chips.push({ key: 'cat', label: f.category });
+    if (typeof f.subcategory === 'string' && f.subcategory) chips.push({ key: 'sub', label: f.subcategory.replace(/-/g, ' ') });
+    if (f.priceMin || f.priceMax) chips.push({ key: 'price', label: `$${f.priceMin || '0'}–$${f.priceMax || '∞'}` });
+    if (f.bedroomsMin) chips.push({ key: 'bd', label: `${f.bedroomsMin}+ bd` });
+    if (f.bathroomsMin) chips.push({ key: 'ba', label: `${f.bathroomsMin}+ ba` });
+    if (typeof f.location === 'string' && f.location) chips.push({ key: 'loc', label: f.location });
+    if (typeof f.city === 'string' && f.city) chips.push({ key: 'city', label: f.city });
+    if (typeof f.province === 'string' && f.province) chips.push({ key: 'prov', label: f.province });
+    return chips;
+  } catch {
+    return [];
+  }
+}
+
 export default function SavedSearchesPage() {
   useUser({ or: 'redirect' });
   const queryClient = useQueryClient();
   const router = useRouter();
 
-  const { data: searches = [], isLoading } = useQuery<SavedSearch[]>({
+  const meta = useQuery<SavedSearchMeta[]>({
     queryKey: ['saved-searches'],
     queryFn: () => fetch('/api/saved-searches').then(r => r.json()),
   });
 
+  const previews = useQuery<DashboardSearchesData>({
+    queryKey: ['dashboard', 'searches'],
+    queryFn: () => fetch('/api/dashboard?tab=searches').then(r => r.json()),
+  });
+
   const deleteMutation = useMutation({
     mutationFn: (id: number) => fetch(`/api/saved-searches/${id}`, { method: 'DELETE' }),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['saved-searches'] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['saved-searches'] });
+      queryClient.invalidateQueries({ queryKey: ['dashboard', 'searches'] });
+    },
   });
 
   const refreshMutation = useMutation({
     mutationFn: () => fetch('/api/saved-searches/check-all', { method: 'POST' }),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['saved-searches'] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['saved-searches'] });
+      queryClient.invalidateQueries({ queryKey: ['dashboard', 'searches'] });
+    },
   });
 
-  function applySearch(search: SavedSearch) {
-    const filters = JSON.parse(search.filters);
-    const params = new URLSearchParams();
-    for (const [key, value] of Object.entries(filters)) {
-      if (value != null && value !== '') {
-        params.set(key, String(value));
-      }
-    }
+  function applySearch(filtersJson: string) {
+    const params = getSearchParams(filtersJson);
     router.push(`/listings?${params.toString()}`);
   }
 
-  function formatFilterSummary(filtersJson: string): string {
-    try {
-      const f = JSON.parse(filtersJson);
-      const parts: string[] = [];
-      if (f.category) parts.push(f.category);
-      if (f.subcategory) parts.push(f.subcategory);
-      if (f.priceMin || f.priceMax) {
-        parts.push(`$${f.priceMin || '0'}-$${f.priceMax || '∞'}`);
-      }
-      if (f.bedroomsMin) parts.push(`${f.bedroomsMin}+ bd`);
-      if (f.location) parts.push(f.location);
-      if (f.province) parts.push(f.province);
-      return parts.join(' · ') || 'All listings';
-    } catch {
-      return 'All listings';
-    }
-  }
+  const isLoading = meta.isLoading || previews.isLoading;
+  const searches = meta.data ?? [];
+  const previewByid = new Map<number, SavedSearchPreview>();
+  for (const s of previews.data?.savedSearches ?? []) previewByid.set(s.id, s);
+  const lastCrawlStart = previews.data?.lastCrawlStart ?? null;
 
-  if (isLoading) {
-    return (
-      <div className="p-6">
-        <h1 className="text-2xl font-bold text-gray-900 mb-4">Saved Searches</h1>
-        <div className="animate-pulse space-y-3">
-          {[...Array(3)].map((_, i) => (
-            <div key={i} className="h-16 bg-gray-200 rounded-lg" />
-          ))}
-        </div>
-      </div>
-    );
-  }
+  const totalNew = searches.reduce((s, x) => s + (x.newMatchCount ?? 0), 0);
 
   return (
-    <div className="p-6">
-      <div className="flex items-center justify-between mb-4">
-        <h1 className="text-2xl font-bold text-gray-900">Saved Searches</h1>
+    <div className="px-6 md:px-10 py-8 max-w-[1300px] mx-auto">
+      {/* Hero */}
+      <div className="flex flex-wrap items-end justify-between gap-4 mb-8">
+        <div>
+          <p className="text-[11px] uppercase tracking-[0.3em] text-stone-500 font-medium">Watching</p>
+          <h1 className="font-serif text-4xl md:text-5xl font-light tracking-tight text-stone-900 mt-1.5">
+            Saved <span className="italic">searches</span>
+          </h1>
+          <p className="text-sm text-stone-500 mt-2">
+            {isLoading ? 'Loading…' : searches.length === 0
+              ? 'Save filters from the browse page to follow new matches.'
+              : (
+                <>
+                  {searches.length} active {searches.length === 1 ? 'search' : 'searches'}
+                  {totalNew > 0 && (
+                    <span className="ml-2 aurora-chip aurora-chip-mint">+{totalNew} new since last check</span>
+                  )}
+                </>
+              )}
+          </p>
+        </div>
         <button
           onClick={() => refreshMutation.mutate()}
-          disabled={refreshMutation.isPending}
-          className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+          disabled={refreshMutation.isPending || searches.length === 0}
+          className="aurora-pill aurora-pill-primary disabled:opacity-40 disabled:cursor-not-allowed"
         >
-          {refreshMutation.isPending ? 'Checking...' : 'Check for New'}
+          <svg className={`w-3.5 h-3.5 ${refreshMutation.isPending ? 'animate-spin' : ''}`} fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h5M20 20v-5h-5M5 9a8 8 0 0114-3M19 15a8 8 0 01-14 3" />
+          </svg>
+          {refreshMutation.isPending ? 'Checking…' : 'Check for new'}
         </button>
       </div>
 
-      {searches.length === 0 ? (
-        <div className="text-center py-12">
-          <p className="text-gray-500">No saved searches yet.</p>
-          <p className="text-sm text-gray-400 mt-1">
-            Use the &quot;Save Search&quot; button on the browse page to save your current filters.
+      {isLoading ? (
+        <div className="space-y-4">
+          {[...Array(2)].map((_, i) => (
+            <div key={i} className="h-64 rounded-3xl aurora-surface animate-pulse" />
+          ))}
+        </div>
+      ) : searches.length === 0 ? (
+        <div className="text-center py-16 rounded-3xl aurora-surface">
+          <div
+            className="inline-flex items-center justify-center w-16 h-16 rounded-full mb-4"
+            style={{ background: 'linear-gradient(135deg, #ecf3ec, #ebe4cd)' }}
+          >
+            <svg className="w-7 h-7 text-stone-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.5}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-4-7 4V5z" />
+            </svg>
+          </div>
+          <p className="font-serif text-2xl text-stone-900">No saved searches yet</p>
+          <p className="text-sm text-stone-500 mt-1">
+            Use the{' '}
+            <Link href="/listings" className="text-stone-800 underline-offset-4 hover:underline">browse page</Link>
+            {' '}and tap <em>Save search</em> after applying filters.
           </p>
         </div>
       ) : (
-        <div className="space-y-3">
-          {searches.map(search => (
-            <div key={search.id} className="bg-white rounded-lg border p-4 flex items-center gap-4">
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2">
-                  <h3 className="text-sm font-semibold text-gray-900">{search.name}</h3>
-                  {search.newMatchCount != null && search.newMatchCount > 0 && (
-                    <span className="bg-blue-500 text-white text-xs px-1.5 py-0.5 rounded-full">
-                      {search.newMatchCount} new
-                    </span>
+        <div className="space-y-6">
+          {searches.map(search => {
+            const preview = previewByid.get(search.id);
+            const listings = preview?.listings ?? [];
+            const newSinceCrawl = lastCrawlStart
+              ? listings.filter(l => l.firstSeenAt >= lastCrawlStart).length
+              : 0;
+            const chips = filterChips(search.filters);
+            return (
+              <div
+                key={search.id}
+                className="rounded-3xl aurora-surface overflow-hidden"
+              >
+                {/* Header */}
+                <div className="px-6 py-5 flex flex-wrap items-start justify-between gap-3 border-b border-stone-200/60">
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <h2 className="font-serif text-2xl text-stone-900">{search.name}</h2>
+                      {newSinceCrawl > 0 && (
+                        <span
+                          className="aurora-chip text-white"
+                          style={{ background: 'linear-gradient(135deg, #4a6b4a, #1a1a1a)', borderColor: 'transparent' }}
+                        >
+                          +{newSinceCrawl} new
+                        </span>
+                      )}
+                    </div>
+                    <div className="flex flex-wrap gap-1.5 mt-2">
+                      {chips.length > 0 ? chips.map(c => (
+                        <span key={c.key} className="aurora-chip capitalize">{c.label}</span>
+                      )) : (
+                        <span className="aurora-chip">All listings</span>
+                      )}
+                    </div>
+                    <div className="flex flex-wrap items-center gap-3 text-xs text-stone-500 mt-2.5">
+                      <span>Saved {formatRelativeDate(search.createdAt)}</span>
+                      {search.lastCheckedAt && (
+                        <>
+                          <span className="w-1 h-1 rounded-full bg-stone-300" />
+                          <span>Checked {formatRelativeDate(search.lastCheckedAt)}</span>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap gap-2 shrink-0">
+                    <button
+                      onClick={() => applySearch(search.filters)}
+                      className="aurora-pill aurora-pill-primary"
+                    >
+                      Run →
+                    </button>
+                    <button
+                      onClick={() => deleteMutation.mutate(search.id)}
+                      className="aurora-pill aurora-pill-ghost hover:text-stone-900"
+                    >
+                      Delete
+                    </button>
+                  </div>
+                </div>
+
+                {/* Listings preview */}
+                <div className="px-6 py-5">
+                  {listings.length === 0 ? (
+                    <p className="text-sm text-stone-500 italic py-6 text-center">No listings match this search yet.</p>
+                  ) : (
+                    <>
+                      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+                        {listings.slice(0, 6).map(listing => {
+                          const isNew = !!lastCrawlStart && listing.firstSeenAt >= lastCrawlStart;
+                          return (
+                            <Link
+                              key={listing.adId}
+                              href={`/listings/${listing.adId}`}
+                              className={`group flex gap-3 p-3 rounded-2xl transition-all border ${
+                                isNew
+                                  ? 'border-emerald-200 bg-emerald-50/40 hover:bg-emerald-50/70'
+                                  : 'border-transparent hover:bg-white/60'
+                              }`}
+                            >
+                              <div className="relative w-20 h-20 rounded-xl overflow-hidden bg-stone-100 flex-shrink-0">
+                                {listing.thumbnail ? (
+                                  // eslint-disable-next-line @next/next/no-img-element
+                                  <img src={listing.thumbnail} alt="" className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500" />
+                                ) : (
+                                  <div className="w-full h-full bg-gradient-to-br from-stone-100 to-stone-200" />
+                                )}
+                                {isNew && (
+                                  <span className="absolute top-1 left-1 aurora-chip aurora-chip-mint text-[9px] px-1.5 py-0">
+                                    New
+                                  </span>
+                                )}
+                              </div>
+                              <div className="flex-1 min-w-0">
+                                <p className="font-serif text-lg text-stone-900 leading-tight">
+                                  {compactPrice(listing.price)}
+                                </p>
+                                <p className="text-xs text-stone-700 truncate mt-0.5">{listing.title || listing.adId}</p>
+                                <p className="text-[11px] text-stone-500 truncate">{listing.location || '—'}</p>
+                                <div className="flex items-center gap-2 mt-1.5 text-[10px] text-stone-500">
+                                  {listing.bedrooms != null && <span>{listing.bedrooms}bd</span>}
+                                  {listing.bathrooms != null && <span>{listing.bathrooms}ba</span>}
+                                  {listing.builtAreaSqm != null && <span>{Math.round(listing.builtAreaSqm)}m²</span>}
+                                  <span className="ml-auto text-stone-400">{formatRelativeDate(listing.firstSeenAt)}</span>
+                                </div>
+                              </div>
+                            </Link>
+                          );
+                        })}
+                      </div>
+                      {listings.length > 6 && (
+                        <div className="mt-4 text-center">
+                          <Link
+                            href={`/listings?${getSearchParams(search.filters).toString()}`}
+                            className="text-sm text-stone-700 hover:text-stone-900 underline-offset-4 hover:underline"
+                          >
+                            View all {listings.length}+ matches →
+                          </Link>
+                        </div>
+                      )}
+                    </>
                   )}
                 </div>
-                <p className="text-xs text-gray-500 mt-0.5">{formatFilterSummary(search.filters)}</p>
-                {search.lastCheckedAt && (
-                  <p className="text-xs text-gray-400 mt-0.5">
-                    Last checked {formatRelativeDate(search.lastCheckedAt)}
-                  </p>
-                )}
               </div>
-              <div className="flex gap-2 shrink-0">
-                <button
-                  onClick={() => applySearch(search)}
-                  className="px-3 py-1.5 text-sm bg-gray-100 rounded hover:bg-gray-200"
-                >
-                  Apply
-                </button>
-                <button
-                  onClick={() => deleteMutation.mutate(search.id)}
-                  className="px-3 py-1.5 text-sm text-red-600 hover:bg-red-50 rounded"
-                >
-                  Delete
-                </button>
-              </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
     </div>

--- a/web/src/app/api/dashboard/trends/route.ts
+++ b/web/src/app/api/dashboard/trends/route.ts
@@ -1,0 +1,109 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/db';
+import { sql } from 'drizzle-orm';
+import { requireUser } from '@/lib/auth';
+
+export async function GET() {
+  await requireUser();
+
+  const now = new Date();
+  const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString();
+  const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString();
+
+  const [dailyNewRaw, dailyRemovedRaw, topCitiesRaw, recentCrawlsRaw, priceBucketsRaw, categoryShareRaw] = await Promise.all([
+    db.all<{ day: string; count: number }>(sql`
+      SELECT to_char(date_trunc('day', first_seen_at::timestamp), 'YYYY-MM-DD') as day,
+             COUNT(*) as count
+      FROM listings
+      WHERE first_seen_at >= ${thirtyDaysAgo}
+      GROUP BY day
+      ORDER BY day
+    `),
+    db.all<{ day: string; count: number }>(sql`
+      SELECT to_char(date_trunc('day', removed_at::timestamp), 'YYYY-MM-DD') as day,
+             COUNT(*) as count
+      FROM listings
+      WHERE removed_at IS NOT NULL AND removed_at >= ${thirtyDaysAgo}
+      GROUP BY day
+      ORDER BY day
+    `),
+    db.all<{ city: string; active: number; new_this_week: number; avg_sale: number | null; avg_rent: number | null }>(sql`
+      SELECT city,
+             COUNT(*) FILTER (WHERE removed_at IS NULL) as active,
+             COUNT(*) FILTER (WHERE first_seen_at >= ${weekAgo}) as new_this_week,
+             AVG(price) FILTER (WHERE removed_at IS NULL AND category = 'sale' AND price IS NOT NULL) as avg_sale,
+             AVG(price) FILTER (WHERE removed_at IS NULL AND category = 'rental' AND price IS NOT NULL) as avg_rent
+      FROM listings
+      WHERE city IS NOT NULL
+      GROUP BY city
+      ORDER BY active DESC
+      LIMIT 8
+    `),
+    db.all<{ id: number; status: string; started_at: string; finished_at: string | null; listings_new: number; listings_updated: number; duration_secs: number | null; errors: number }>(sql`
+      SELECT id, status, started_at, finished_at, listings_new, listings_updated, duration_secs, errors
+      FROM crawl_runs
+      ORDER BY started_at DESC
+      LIMIT 7
+    `),
+    db.all<{ bucket: string; count: number }>(sql`
+      SELECT bucket, COUNT(*) as count FROM (
+        SELECT CASE
+          WHEN price < 100000 THEN '<100K'
+          WHEN price < 250000 THEN '100-250K'
+          WHEN price < 500000 THEN '250-500K'
+          WHEN price < 1000000 THEN '500K-1M'
+          WHEN price < 2500000 THEN '1-2.5M'
+          ELSE '2.5M+'
+        END as bucket
+        FROM listings
+        WHERE removed_at IS NULL AND category = 'sale' AND price IS NOT NULL
+      ) buckets
+      GROUP BY bucket
+    `),
+    db.all<{ category: string; active: number }>(sql`
+      SELECT category, COUNT(*) FILTER (WHERE removed_at IS NULL) as active
+      FROM listings
+      GROUP BY category
+      ORDER BY active DESC
+    `),
+  ]);
+
+  const dailyNewMap = new Map<string, number>();
+  for (const row of dailyNewRaw) dailyNewMap.set(row.day, Number(row.count));
+  const dailyRemovedMap = new Map<string, number>();
+  for (const row of dailyRemovedRaw) dailyRemovedMap.set(row.day, Number(row.count));
+
+  const dailyTrend: Array<{ day: string; added: number; removed: number }> = [];
+  for (let i = 29; i >= 0; i--) {
+    const d = new Date(now.getTime() - i * 24 * 60 * 60 * 1000);
+    const key = d.toISOString().slice(0, 10);
+    dailyTrend.push({ day: key, added: dailyNewMap.get(key) ?? 0, removed: dailyRemovedMap.get(key) ?? 0 });
+  }
+
+  const bucketOrder = ['<100K', '100-250K', '250-500K', '500K-1M', '1-2.5M', '2.5M+'];
+  const bucketMap = new Map(priceBucketsRaw.map((b) => [b.bucket, Number(b.count)]));
+  const priceDistribution = bucketOrder.map((b) => ({ bucket: b, count: bucketMap.get(b) ?? 0 }));
+
+  return NextResponse.json({
+    dailyTrend,
+    topCities: topCitiesRaw.map((c) => ({
+      city: c.city,
+      active: Number(c.active),
+      newThisWeek: Number(c.new_this_week),
+      avgSale: c.avg_sale != null ? Number(c.avg_sale) : null,
+      avgRent: c.avg_rent != null ? Number(c.avg_rent) : null,
+    })),
+    recentCrawls: recentCrawlsRaw.map((r) => ({
+      id: r.id,
+      status: r.status,
+      startedAt: r.started_at,
+      finishedAt: r.finished_at,
+      listingsNew: Number(r.listings_new),
+      listingsUpdated: Number(r.listings_updated),
+      durationSecs: r.duration_secs != null ? Number(r.duration_secs) : null,
+      errors: Number(r.errors),
+    })),
+    priceDistribution,
+    categoryShare: categoryShareRaw.map((c) => ({ category: c.category, active: Number(c.active) })),
+  });
+}

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -40,3 +40,19 @@ body {
   color: #111827;
   font-family: Arial, Helvetica, sans-serif;
 }
+
+/* Tailwind v4 dropped the default cursor:pointer for buttons.
+   Restore it for every interactive element across the app. */
+button:not(:disabled),
+[role="button"]:not(:disabled),
+select:not(:disabled),
+summary,
+label[for] {
+  cursor: pointer;
+}
+
+button:disabled,
+[role="button"][aria-disabled="true"],
+select:disabled {
+  cursor: not-allowed;
+}

--- a/web/src/components/agents/AgentLeaderboard.tsx
+++ b/web/src/components/agents/AgentLeaderboard.tsx
@@ -161,18 +161,13 @@ export function AgentLeaderboard() {
           </button>
         </div>
 
-        <div className="relative flex-1 min-w-[200px]">
-          <svg className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-stone-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.8}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5-5m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-          </svg>
-          <input
-            type="text"
-            placeholder={view === 'agencies' ? 'Search agencies…' : 'Search agents…'}
-            value={search}
-            onChange={e => setSearch(e.target.value)}
-            className="aurora-input w-full pl-9"
-          />
-        </div>
+        <input
+          type="text"
+          placeholder={view === 'agencies' ? 'Search agencies…' : 'Search agents…'}
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          className="aurora-input flex-1 min-w-[200px]"
+        />
 
         <LocationCombobox
           locations={data?.locations || []}

--- a/web/src/components/agents/AgentLeaderboard.tsx
+++ b/web/src/components/agents/AgentLeaderboard.tsx
@@ -42,12 +42,19 @@ interface ApiResponse {
 }
 
 const SORT_OPTIONS = [
-  { value: 'listings_desc', label: 'Most Listings' },
-  { value: 'listings_asc', label: 'Fewest Listings' },
-  { value: 'value_desc', label: 'Highest Value' },
-  { value: 'avg_price_desc', label: 'Highest Avg Price' },
-  { value: 'name_asc', label: 'Name A-Z' },
+  { value: 'listings_desc', label: 'Most listings' },
+  { value: 'listings_asc', label: 'Fewest listings' },
+  { value: 'value_desc', label: 'Highest portfolio value' },
+  { value: 'avg_price_desc', label: 'Highest avg price' },
+  { value: 'name_asc', label: 'Name A–Z' },
 ];
+
+function compactPrice(p: number | null | undefined): string {
+  if (p == null) return '—';
+  if (p >= 1_000_000) return `$${(p / 1_000_000).toFixed(2)}M`;
+  if (p >= 1_000) return `$${(p / 1_000).toFixed(0)}K`;
+  return `$${Math.round(p)}`;
+}
 
 export function AgentLeaderboard() {
   const [view, setView] = useState<'agencies' | 'agents'>('agencies');
@@ -88,42 +95,84 @@ export function AgentLeaderboard() {
 
   return (
     <div>
-      {/* Stats Row */}
+      {/* Stats */}
       <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
-        <StatCard label="Agencies / Sellers" value={stats?.totalSellers ?? '—'} />
-        <StatCard label="Individual Agents" value={stats?.totalIndividualAgents ?? '—'} />
-        <StatCard label="Total Portfolio Value" value={stats ? formatPrice(stats.totalPortfolioValue) : '—'} />
-        <StatCard label="Avg Listings/Seller" value={stats?.avgListingsPerSeller ?? '—'} />
+        <StatCard label="Agencies / sellers" value={stats ? stats.totalSellers.toLocaleString() : '—'} />
+        <StatCard label="Individual agents" value={stats ? stats.totalIndividualAgents.toLocaleString() : '—'} />
+        <StatCard label="Total portfolio value" value={stats ? compactPrice(stats.totalPortfolioValue) : '—'} />
+        <StatCard label="Avg listings / seller" value={stats ? String(stats.avgListingsPerSeller) : '—'} />
       </div>
 
-      {/* View Tabs + Filters */}
-      <div className="flex flex-wrap items-center gap-3 mb-4">
-        <div className="flex bg-gray-100 rounded-lg p-0.5">
+      {/* Top performers — only on first page, no search/filter */}
+      {!isLoading && rows.length > 0 && page === 1 && !debouncedSearch && view === 'agencies' && (
+        <div className="mb-6">
+          <h2 className="font-serif text-xl text-stone-900 mb-3">
+            <span className="aurora-rule">Top performers</span>
+          </h2>
+          <div className="grid grid-cols-2 lg:grid-cols-5 gap-3">
+            {(rows as AgencyRow[]).slice(0, 5).map((agent, i) => (
+              <Link
+                key={agent.name}
+                href={`/agents/${encodeURIComponent(agent.name)}`}
+                className="group relative rounded-2xl aurora-surface p-4 overflow-hidden hover:-translate-y-0.5 hover:shadow-lg transition-all"
+              >
+                <div
+                  className="absolute -top-10 -right-10 w-24 h-24 rounded-full opacity-50 blur-2xl group-hover:opacity-80 transition-opacity"
+                  style={{ background: i === 0 ? '#c8dcc7' : i === 1 ? '#ebe4cd' : i === 2 ? '#cfd8e3' : '#e7e5e4' }}
+                />
+                <div className="relative">
+                  <div className="flex items-center gap-2 mb-2">
+                    <span className="font-serif text-stone-900 text-2xl">
+                      {i === 0 ? '①' : i === 1 ? '②' : i === 2 ? '③' : `#${i + 1}`}
+                    </span>
+                  </div>
+                  <p className="font-serif text-base text-stone-900 truncate">{agent.name}</p>
+                  <p className="text-xs text-stone-500 truncate mt-0.5">{agent.primaryLocation || 'Various areas'}</p>
+                  <div className="mt-3 flex items-baseline gap-3 text-stone-700">
+                    <span className="font-serif text-xl tabular-nums">{agent.listingCount}</span>
+                    <span className="text-[10px] uppercase tracking-wider text-stone-500">listings</span>
+                  </div>
+                  <p className="text-xs text-stone-500 mt-0.5 tabular-nums">{compactPrice(agent.portfolioValue)} portfolio</p>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Filters */}
+      <div className="aurora-surface rounded-2xl p-4 mb-4 flex flex-wrap items-center gap-2.5">
+        <div className="flex bg-white/70 rounded-full p-0.5 border border-stone-200/60">
           <button
             onClick={() => { setView('agencies'); setPage(1); setSearch(''); setDebouncedSearch(''); setLocation(''); }}
-            className={`px-3 py-1.5 text-sm rounded-md transition-colors ${
-              view === 'agencies' ? 'bg-white text-gray-900 shadow-sm font-medium' : 'text-gray-500 hover:text-gray-700'
+            className={`px-3.5 py-1.5 text-sm rounded-full transition-colors ${
+              view === 'agencies' ? 'bg-stone-900 text-white' : 'text-stone-600 hover:text-stone-900'
             }`}
           >
             Agencies
           </button>
           <button
             onClick={() => { setView('agents'); setPage(1); setSearch(''); setDebouncedSearch(''); setLocation(''); }}
-            className={`px-3 py-1.5 text-sm rounded-md transition-colors ${
-              view === 'agents' ? 'bg-white text-gray-900 shadow-sm font-medium' : 'text-gray-500 hover:text-gray-700'
+            className={`px-3.5 py-1.5 text-sm rounded-full transition-colors ${
+              view === 'agents' ? 'bg-stone-900 text-white' : 'text-stone-600 hover:text-stone-900'
             }`}
           >
-            Individual Agents
+            Individual agents
           </button>
         </div>
 
-        <input
-          type="text"
-          placeholder={view === 'agencies' ? 'Search agencies...' : 'Search agents...'}
-          value={search}
-          onChange={e => setSearch(e.target.value)}
-          className="px-3 py-2 border rounded-md text-sm w-64 focus:outline-none focus:ring-2 focus:ring-blue-500"
-        />
+        <div className="relative flex-1 min-w-[200px]">
+          <svg className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-stone-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.8}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5-5m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+          </svg>
+          <input
+            type="text"
+            placeholder={view === 'agencies' ? 'Search agencies…' : 'Search agents…'}
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            className="aurora-input w-full pl-9"
+          />
+        </div>
 
         <LocationCombobox
           locations={data?.locations || []}
@@ -134,7 +183,7 @@ export function AgentLeaderboard() {
         <select
           value={sort}
           onChange={e => { setSort(e.target.value); setPage(1); }}
-          className="px-3 py-2 border rounded-md text-sm bg-white ml-auto"
+          className="aurora-input"
         >
           {SORT_OPTIONS.map(opt => (
             <option key={opt.value} value={opt.value}>{opt.label}</option>
@@ -143,7 +192,7 @@ export function AgentLeaderboard() {
       </div>
 
       {/* Table */}
-      <div className="bg-white rounded-lg border overflow-hidden">
+      <div className="rounded-2xl aurora-surface overflow-hidden">
         <div className="overflow-x-auto">
           {view === 'agencies' ? (
             <AgenciesTable rows={rows as AgencyRow[]} isLoading={isLoading} />
@@ -155,59 +204,26 @@ export function AgentLeaderboard() {
 
       {/* Pagination */}
       {pagination && pagination.totalPages > 1 && (
-        <div className="flex justify-center items-center gap-2 mt-4">
+        <div className="flex justify-center items-center gap-3 mt-6">
           <button
             onClick={() => setPage(p => Math.max(1, p - 1))}
             disabled={page <= 1}
-            className="px-3 py-1.5 text-sm bg-white border rounded disabled:opacity-50 hover:bg-gray-50"
+            className="aurora-pill aurora-pill-ghost disabled:opacity-40 disabled:cursor-not-allowed"
           >
-            Previous
+            ← Previous
           </button>
-          <span className="text-sm text-gray-600">
-            Page {pagination.page} of {pagination.totalPages}
-          </span>
+          <div className="aurora-surface px-4 py-2 rounded-full text-sm text-stone-700">
+            <span className="font-serif text-stone-900">{pagination.page}</span>
+            <span className="text-stone-400 mx-2">/</span>
+            <span className="text-stone-500">{pagination.totalPages}</span>
+          </div>
           <button
             onClick={() => setPage(p => Math.min(pagination.totalPages, p + 1))}
             disabled={page >= pagination.totalPages}
-            className="px-3 py-1.5 text-sm bg-white border rounded disabled:opacity-50 hover:bg-gray-50"
+            className="aurora-pill aurora-pill-ghost disabled:opacity-40 disabled:cursor-not-allowed"
           >
-            Next
+            Next →
           </button>
-        </div>
-      )}
-
-      {/* Top 5 Performers */}
-      {!isLoading && rows.length > 0 && page === 1 && !debouncedSearch && view === 'agencies' && (
-        <div className="mt-8">
-          <h2 className="text-lg font-semibold text-gray-900 mb-4">Top Performers</h2>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4">
-            {(rows as AgencyRow[]).slice(0, 5).map((agent, i) => (
-              <Link
-                key={agent.name}
-                href={`/agents/${encodeURIComponent(agent.name)}`}
-                className={`block p-4 rounded-lg border-2 transition-shadow hover:shadow-md ${
-                  i === 0 ? 'border-yellow-400 bg-yellow-50' :
-                  i === 1 ? 'border-gray-300 bg-gray-50' :
-                  i === 2 ? 'border-amber-600 bg-amber-50' :
-                  'border-gray-200 bg-white'
-                }`}
-              >
-                <div className="flex items-center gap-2 mb-2">
-                  <span className={`text-lg font-bold ${
-                    i === 0 ? 'text-yellow-600' : i === 1 ? 'text-gray-500' : i === 2 ? 'text-amber-700' : 'text-gray-400'
-                  }`}>
-                    #{i + 1}
-                  </span>
-                  <span className="font-semibold text-sm text-gray-900 truncate">{agent.name}</span>
-                </div>
-                <div className="space-y-1 text-xs text-gray-600">
-                  <p>{agent.listingCount} listings</p>
-                  <p>{formatPrice(agent.portfolioValue)}</p>
-                  <p className="truncate">{agent.primaryLocation || 'Various'}</p>
-                </div>
-              </Link>
-            ))}
-          </div>
         </div>
       )}
     </div>
@@ -218,55 +234,51 @@ function AgenciesTable({ rows, isLoading }: { rows: AgencyRow[]; isLoading: bool
   return (
     <table className="w-full text-sm">
       <thead>
-        <tr className="border-b bg-gray-50 text-left text-gray-500 text-xs uppercase">
+        <tr className="text-left text-[11px] uppercase tracking-wider text-stone-500 border-b border-stone-200/60">
           <th className="px-4 py-3 w-12">#</th>
-          <th className="px-4 py-3">Name</th>
-          <th className="px-4 py-3">Type</th>
-          <th className="px-4 py-3 text-right">Agents</th>
-          <th className="px-4 py-3 text-right">Listings</th>
-          <th className="px-4 py-3 text-right">Portfolio Value</th>
-          <th className="px-4 py-3 text-right">Avg Price</th>
-          <th className="px-4 py-3">Primary Area</th>
-          <th className="px-4 py-3 text-center">Verified</th>
-          <th className="px-4 py-3 text-center">WA</th>
+          <th className="px-4 py-3 font-medium">Name</th>
+          <th className="px-4 py-3 font-medium">Type</th>
+          <th className="px-4 py-3 text-right font-medium">Agents</th>
+          <th className="px-4 py-3 text-right font-medium">Listings</th>
+          <th className="px-4 py-3 text-right font-medium">Portfolio</th>
+          <th className="px-4 py-3 text-right font-medium">Avg price</th>
+          <th className="px-4 py-3 font-medium">Primary area</th>
+          <th className="px-4 py-3 text-center font-medium">✓</th>
+          <th className="px-4 py-3 text-center font-medium">WA</th>
         </tr>
       </thead>
       <tbody>
         {isLoading ? (
           Array.from({ length: 10 }).map((_, i) => (
-            <tr key={i} className="border-b">
-              <td colSpan={10} className="px-4 py-3"><div className="h-4 bg-gray-200 rounded animate-pulse" /></td>
+            <tr key={i} className="border-b border-stone-200/40">
+              <td colSpan={10} className="px-4 py-3"><div className="h-4 bg-stone-200/60 rounded animate-pulse" /></td>
             </tr>
           ))
         ) : rows.length === 0 ? (
-          <tr><td colSpan={10} className="px-4 py-8 text-center text-gray-500">No results found</td></tr>
+          <tr><td colSpan={10} className="px-4 py-12 text-center text-stone-500 italic">No results found</td></tr>
         ) : rows.map(row => (
-          <tr key={row.name} className="border-b hover:bg-gray-50 transition-colors">
-            <td className="px-4 py-3 text-gray-400 font-mono text-xs">{row.rank}</td>
+          <tr key={row.name} className="border-b border-stone-200/40 last:border-0 hover:bg-white/50 transition-colors">
+            <td className="px-4 py-3 text-stone-400 tabular-nums">{row.rank}</td>
             <td className="px-4 py-3">
-              <Link href={`/agents/${encodeURIComponent(row.name)}`} className="font-medium text-blue-600 hover:underline">
+              <Link href={`/agents/${encodeURIComponent(row.name)}`} className="font-medium text-stone-900 underline-offset-4 hover:underline">
                 {row.name}
               </Link>
             </td>
             <td className="px-4 py-3">
-              {row.type && (
-                <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${
-                  row.type === 'agent' ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 text-gray-700'
-                }`}>{row.type}</span>
-              )}
+              {row.type && <span className="aurora-chip capitalize">{row.type}</span>}
             </td>
-            <td className="px-4 py-3 text-right text-gray-600">{row.agentCount || '—'}</td>
-            <td className="px-4 py-3 text-right font-medium">
+            <td className="px-4 py-3 text-right text-stone-600 tabular-nums">{row.agentCount || '—'}</td>
+            <td className="px-4 py-3 text-right font-medium text-stone-900 tabular-nums">
               {row.listingCount}
               {row.totalListingCount > row.listingCount && (
-                <span className="text-xs text-gray-400 ml-1">/ {row.totalListingCount}</span>
+                <span className="text-xs text-stone-400 ml-1">/ {row.totalListingCount}</span>
               )}
             </td>
-            <td className="px-4 py-3 text-right">{formatPrice(row.portfolioValue)}</td>
-            <td className="px-4 py-3 text-right">{formatPrice(row.avgPrice)}</td>
-            <td className="px-4 py-3 text-gray-600 text-xs truncate max-w-[180px]">{row.primaryLocation || '—'}</td>
-            <td className="px-4 py-3 text-center">{row.verified && <span className="text-green-600">&#10003;</span>}</td>
-            <td className="px-4 py-3 text-center">{row.whatsapp && <span className="text-green-600">&#10003;</span>}</td>
+            <td className="px-4 py-3 text-right tabular-nums text-stone-700">{compactPrice(row.portfolioValue)}</td>
+            <td className="px-4 py-3 text-right tabular-nums text-stone-700">{compactPrice(row.avgPrice)}</td>
+            <td className="px-4 py-3 text-stone-600 text-xs truncate max-w-[180px]">{row.primaryLocation || '—'}</td>
+            <td className="px-4 py-3 text-center">{row.verified && <span className="text-emerald-600">✓</span>}</td>
+            <td className="px-4 py-3 text-center">{row.whatsapp && <span className="text-emerald-600">✓</span>}</td>
           </tr>
         ))}
       </tbody>
@@ -278,36 +290,36 @@ function AgentsTable({ rows, isLoading }: { rows: AgentRow[]; isLoading: boolean
   return (
     <table className="w-full text-sm">
       <thead>
-        <tr className="border-b bg-gray-50 text-left text-gray-500 text-xs uppercase">
+        <tr className="text-left text-[11px] uppercase tracking-wider text-stone-500 border-b border-stone-200/60">
           <th className="px-4 py-3 w-12">#</th>
-          <th className="px-4 py-3">Agent Name</th>
-          <th className="px-4 py-3">Agency</th>
-          <th className="px-4 py-3 text-right">Listings</th>
-          <th className="px-4 py-3 text-right">Portfolio Value</th>
-          <th className="px-4 py-3 text-right">Avg Price</th>
+          <th className="px-4 py-3 font-medium">Agent name</th>
+          <th className="px-4 py-3 font-medium">Agency</th>
+          <th className="px-4 py-3 text-right font-medium">Listings</th>
+          <th className="px-4 py-3 text-right font-medium">Portfolio</th>
+          <th className="px-4 py-3 text-right font-medium">Avg price</th>
         </tr>
       </thead>
       <tbody>
         {isLoading ? (
           Array.from({ length: 10 }).map((_, i) => (
-            <tr key={i} className="border-b">
-              <td colSpan={6} className="px-4 py-3"><div className="h-4 bg-gray-200 rounded animate-pulse" /></td>
+            <tr key={i} className="border-b border-stone-200/40">
+              <td colSpan={6} className="px-4 py-3"><div className="h-4 bg-stone-200/60 rounded animate-pulse" /></td>
             </tr>
           ))
         ) : rows.length === 0 ? (
-          <tr><td colSpan={6} className="px-4 py-8 text-center text-gray-500">No results found</td></tr>
+          <tr><td colSpan={6} className="px-4 py-12 text-center text-stone-500 italic">No results found</td></tr>
         ) : rows.map(row => (
-          <tr key={`${row.name}-${row.agency}`} className="border-b hover:bg-gray-50 transition-colors">
-            <td className="px-4 py-3 text-gray-400 font-mono text-xs">{row.rank}</td>
-            <td className="px-4 py-3 font-medium text-gray-900">{row.name}</td>
+          <tr key={`${row.name}-${row.agency}`} className="border-b border-stone-200/40 last:border-0 hover:bg-white/50 transition-colors">
+            <td className="px-4 py-3 text-stone-400 tabular-nums">{row.rank}</td>
+            <td className="px-4 py-3 font-medium text-stone-900">{row.name}</td>
             <td className="px-4 py-3">
-              <Link href={`/agents/${encodeURIComponent(row.agency)}`} className="text-blue-600 hover:underline text-sm">
+              <Link href={`/agents/${encodeURIComponent(row.agency)}`} className="text-stone-700 underline-offset-4 hover:underline text-sm">
                 {row.agency}
               </Link>
             </td>
-            <td className="px-4 py-3 text-right font-medium">{row.listingCount}</td>
-            <td className="px-4 py-3 text-right">{formatPrice(row.portfolioValue)}</td>
-            <td className="px-4 py-3 text-right">{formatPrice(row.avgPrice)}</td>
+            <td className="px-4 py-3 text-right font-medium text-stone-900 tabular-nums">{row.listingCount}</td>
+            <td className="px-4 py-3 text-right tabular-nums text-stone-700">{compactPrice(row.portfolioValue)}</td>
+            <td className="px-4 py-3 text-right tabular-nums text-stone-700">{compactPrice(row.avgPrice)}</td>
           </tr>
         ))}
       </tbody>
@@ -315,11 +327,11 @@ function AgentsTable({ rows, isLoading }: { rows: AgentRow[]; isLoading: boolean
   );
 }
 
-function StatCard({ label, value }: { label: string; value: string | number }) {
+function StatCard({ label, value }: { label: string; value: string }) {
   return (
-    <div className="bg-white rounded-lg border p-4">
-      <p className="text-xs text-gray-500 uppercase tracking-wide">{label}</p>
-      <p className="text-2xl font-bold text-gray-900 mt-1">{value}</p>
+    <div className="aurora-surface rounded-2xl p-5">
+      <p className="text-[10px] uppercase tracking-[0.2em] text-stone-500 font-medium">{label}</p>
+      <p className="font-serif text-3xl font-light text-stone-900 mt-2 tabular-nums">{value}</p>
     </div>
   );
 }
@@ -354,54 +366,56 @@ function LocationCombobox({
     return () => document.removeEventListener('mousedown', handleClick);
   }, []);
 
-  const displayValue = value || 'All Areas';
-
   return (
     <div ref={containerRef} className="relative">
       <button
         type="button"
         onClick={() => { setOpen(!open); setQuery(''); setTimeout(() => inputRef.current?.focus(), 0); }}
-        className="flex items-center gap-1.5 px-3 py-2 border rounded-md text-sm bg-white hover:bg-gray-50 min-w-[180px]"
+        className="aurora-input flex items-center gap-1.5 min-w-[180px]"
       >
-        <span className="truncate flex-1 text-left">{displayValue}</span>
-        <svg className="w-4 h-4 text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        <span className={`truncate flex-1 text-left ${value ? 'text-stone-900' : 'text-stone-500'}`}>
+          {value || 'All areas'}
+        </span>
+        <svg className="w-3.5 h-3.5 text-stone-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
         </svg>
       </button>
 
       {open && (
-        <div className="absolute z-20 mt-1 w-72 bg-white border rounded-lg shadow-lg">
-          <div className="p-2 border-b">
+        <div className="absolute z-20 mt-1.5 w-72 rounded-2xl shadow-xl aurora-surface-strong overflow-hidden">
+          <div className="p-2 border-b border-stone-200/60">
             <input
               ref={inputRef}
               type="text"
-              placeholder="Type to filter..."
+              placeholder="Type to filter…"
               value={query}
               onChange={(e) => setQuery(e.target.value)}
-              className="w-full px-2.5 py-1.5 text-sm border rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="aurora-input w-full text-sm"
             />
           </div>
           <div className="max-h-60 overflow-y-auto">
             <button
               onClick={() => { onChange(''); setOpen(false); setQuery(''); }}
-              className={`w-full text-left px-3 py-2 text-sm hover:bg-gray-50 ${!value ? 'bg-blue-50 text-blue-700 font-medium' : ''}`}
+              className={`w-full text-left px-3 py-2 text-sm transition-colors hover:bg-emerald-50/70 ${
+                !value ? 'bg-emerald-50 text-emerald-800 font-medium' : 'text-stone-700'
+              }`}
             >
-              All Areas
+              All areas
             </button>
             {filtered.map((loc) => (
               <button
                 key={loc.value}
                 onClick={() => { onChange(loc.value); setOpen(false); setQuery(''); }}
-                className={`w-full text-left px-3 py-2 text-sm hover:bg-gray-50 flex justify-between ${
-                  value === loc.value ? 'bg-blue-50 text-blue-700 font-medium' : ''
+                className={`w-full text-left px-3 py-2 text-sm hover:bg-emerald-50/70 flex justify-between transition-colors ${
+                  value === loc.value ? 'bg-emerald-50 text-emerald-800 font-medium' : 'text-stone-700'
                 }`}
               >
                 <span className="truncate">{loc.value}</span>
-                <span className="text-gray-400 text-xs ml-2 flex-shrink-0">{loc.count}</span>
+                <span className="text-stone-400 text-xs ml-2 flex-shrink-0 tabular-nums">{loc.count}</span>
               </button>
             ))}
             {filtered.length === 0 && (
-              <div className="px-3 py-4 text-sm text-gray-400 text-center">No matching areas</div>
+              <div className="px-3 py-4 text-sm text-stone-400 text-center italic">No matching areas</div>
             )}
           </div>
         </div>

--- a/web/src/components/agents/AgentListings.tsx
+++ b/web/src/components/agents/AgentListings.tsx
@@ -41,7 +41,7 @@ export function AgentListings({ listings, pagination, onPageChange, locations, s
   return (
     <div>
       {/* Filters */}
-      <div className="flex gap-3 mb-3 items-center">
+      <div className="flex flex-wrap gap-2.5 mb-4 items-center">
         {locations.length > 1 && (
           <LocationFilter
             locations={locations}
@@ -52,7 +52,7 @@ export function AgentListings({ listings, pagination, onPageChange, locations, s
         <select
           value={status}
           onChange={e => onStatusChange(e.target.value)}
-          className="px-3 py-1.5 text-sm border border-gray-300 rounded bg-white text-gray-900"
+          className="aurora-input"
         >
           <option value="active">Active only</option>
           <option value="removed">Removed only</option>
@@ -61,67 +61,70 @@ export function AgentListings({ listings, pagination, onPageChange, locations, s
       </div>
 
       {listings.length === 0 ? (
-        <div className="bg-white rounded-lg border p-8 text-center text-gray-400">
+        <div className="aurora-surface rounded-2xl p-10 text-center text-stone-500 italic">
           No listings found{selectedLocation ? ` in ${selectedLocation}` : ''}
         </div>
       ) : (
-        <div className="bg-white rounded-lg border overflow-hidden">
+        <div className="aurora-surface rounded-2xl overflow-hidden">
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
-                <tr className="border-b bg-gray-50 text-left text-xs text-gray-500 uppercase">
-                  <th className="px-3 py-2.5 w-12"></th>
-                  <th className="px-3 py-2.5">Title</th>
-                  <th className="px-3 py-2.5 text-right">Price</th>
-                  <th className="px-3 py-2.5">Location</th>
-                  <th className="px-3 py-2.5 text-center">Beds</th>
-                  <th className="px-3 py-2.5 text-center">Baths</th>
-                  <th className="px-3 py-2.5 text-right">Area</th>
-                  <th className="px-3 py-2.5">Published</th>
-                  <th className="px-3 py-2.5 text-right">Favs</th>
+                <tr className="text-left text-[11px] uppercase tracking-wider text-stone-500 border-b border-stone-200/60">
+                  <th className="px-3 py-3 w-12 font-medium"></th>
+                  <th className="px-3 py-3 font-medium">Title</th>
+                  <th className="px-3 py-3 text-right font-medium">Price</th>
+                  <th className="px-3 py-3 font-medium">Location</th>
+                  <th className="px-3 py-3 text-center font-medium">Bd</th>
+                  <th className="px-3 py-3 text-center font-medium">Ba</th>
+                  <th className="px-3 py-3 text-right font-medium">Area</th>
+                  <th className="px-3 py-3 font-medium">Published</th>
+                  <th className="px-3 py-3 text-right font-medium">Favs</th>
                 </tr>
               </thead>
               <tbody>
                 {listings.map(listing => (
-                  <tr key={listing.adId} className={`border-b hover:bg-gray-50 transition-colors ${listing.removedAt ? 'opacity-60 bg-red-50' : ''}`}>
+                  <tr key={listing.adId} className={`border-b border-stone-200/40 last:border-0 hover:bg-white/50 transition-colors ${listing.removedAt ? 'opacity-60' : ''}`}>
                     <td className="px-3 py-2">
                       {listing.thumbnail ? (
+                        // eslint-disable-next-line @next/next/no-img-element
                         <img
                           src={listing.thumbnail}
                           alt=""
-                          className="w-10 h-10 object-cover rounded"
+                          className="w-10 h-10 object-cover rounded-lg"
                           loading="lazy"
                         />
                       ) : (
-                        <div className="w-10 h-10 bg-gray-200 rounded" />
+                        <div className="w-10 h-10 rounded-lg bg-gradient-to-br from-stone-100 to-stone-200" />
                       )}
                     </td>
                     <td className="px-3 py-2">
                       <Link
                         href={`/listings/${listing.adId}`}
-                        className={`hover:underline line-clamp-1 max-w-[250px] block ${listing.removedAt ? 'text-red-600' : 'text-blue-600'}`}
+                        className="text-stone-900 underline-offset-4 hover:underline line-clamp-1 max-w-[260px] block"
                       >
                         {listing.title || 'Untitled'}
                       </Link>
                       {listing.removedAt && (
-                        <span className="text-xs text-red-400">Removed {formatRelativeDate(listing.removedAt)}</span>
+                        <span className="aurora-chip aurora-chip-warn mt-1">
+                          Removed {formatRelativeDate(listing.removedAt)}
+                        </span>
                       )}
                     </td>
-                    <td className="px-3 py-2 text-right font-medium whitespace-nowrap">
+                    <td className="px-3 py-2 text-right font-medium whitespace-nowrap text-stone-900 tabular-nums">
                       {formatPrice(listing.price, listing.currency || 'USD')}
                     </td>
-                    <td className="px-3 py-2 text-gray-600 text-xs truncate max-w-[150px]">
+                    <td className="px-3 py-2 text-stone-600 text-xs truncate max-w-[150px]">
                       {listing.location || '—'}
                     </td>
-                    <td className="px-3 py-2 text-center text-gray-600">{listing.bedrooms ?? '—'}</td>
-                    <td className="px-3 py-2 text-center text-gray-600">{listing.bathrooms ?? '—'}</td>
-                    <td className="px-3 py-2 text-right text-gray-600 whitespace-nowrap">
+                    <td className="px-3 py-2 text-center text-stone-600 tabular-nums">{listing.bedrooms ?? '—'}</td>
+                    <td className="px-3 py-2 text-center text-stone-600 tabular-nums">{listing.bathrooms ?? '—'}</td>
+                    <td className="px-3 py-2 text-right text-stone-600 whitespace-nowrap tabular-nums">
                       {listing.area ? `${listing.area.toLocaleString()} m²` : '—'}
                     </td>
-                    <td className="px-3 py-2 text-gray-500 text-xs whitespace-nowrap">
+                    <td className="px-3 py-2 text-stone-500 text-xs whitespace-nowrap">
                       {formatDate(listing.publishedAt)}
                     </td>
-                    <td className="px-3 py-2 text-right text-gray-600">{listing.favorites ?? 0}</td>
+                    <td className="px-3 py-2 text-right text-stone-600 tabular-nums">{listing.favorites ?? 0}</td>
                   </tr>
                 ))}
               </tbody>
@@ -132,23 +135,25 @@ export function AgentListings({ listings, pagination, onPageChange, locations, s
 
       {/* Pagination */}
       {pagination.totalPages > 1 && (
-        <div className="flex justify-center items-center gap-2 mt-4">
+        <div className="flex justify-center items-center gap-3 mt-6">
           <button
             onClick={() => onPageChange(pagination.page - 1)}
             disabled={pagination.page <= 1}
-            className="px-3 py-1.5 text-sm bg-white border rounded disabled:opacity-50 hover:bg-gray-50"
+            className="aurora-pill aurora-pill-ghost disabled:opacity-40 disabled:cursor-not-allowed"
           >
-            Previous
+            ← Previous
           </button>
-          <span className="text-sm text-gray-600">
-            Page {pagination.page} of {pagination.totalPages}
-          </span>
+          <div className="aurora-surface px-4 py-2 rounded-full text-sm text-stone-700">
+            <span className="font-serif text-stone-900">{pagination.page}</span>
+            <span className="text-stone-400 mx-2">/</span>
+            <span className="text-stone-500">{pagination.totalPages}</span>
+          </div>
           <button
             onClick={() => onPageChange(pagination.page + 1)}
             disabled={pagination.page >= pagination.totalPages}
-            className="px-3 py-1.5 text-sm bg-white border rounded disabled:opacity-50 hover:bg-gray-50"
+            className="aurora-pill aurora-pill-ghost disabled:opacity-40 disabled:cursor-not-allowed"
           >
-            Next
+            Next →
           </button>
         </div>
       )}
@@ -191,59 +196,59 @@ function LocationFilter({
       <button
         type="button"
         onClick={() => { setOpen(!open); setQuery(''); setTimeout(() => inputRef.current?.focus(), 0); }}
-        className="flex items-center gap-1.5 px-3 py-1.5 border rounded-md text-sm bg-white hover:bg-gray-50"
+        className="aurora-input flex items-center gap-1.5"
       >
-        <svg className="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+        <svg className="w-3.5 h-3.5 text-stone-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.8}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+          <path strokeLinecap="round" strokeLinejoin="round" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
         </svg>
-        <span className="truncate">{value || 'All Locations'}</span>
+        <span className={`truncate ${value ? 'text-stone-900' : 'text-stone-500'}`}>{value || 'All locations'}</span>
         {value && (
           <span
             onClick={(e) => { e.stopPropagation(); onChange(''); setOpen(false); }}
-            className="ml-1 text-gray-400 hover:text-gray-600"
+            className="ml-1 text-stone-400 hover:text-stone-700"
           >
             &times;
           </span>
         )}
-        <svg className="w-3 h-3 text-gray-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        <svg className="w-3 h-3 text-stone-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
         </svg>
       </button>
 
       {open && (
-        <div className="absolute z-20 mt-1 w-64 bg-white border rounded-lg shadow-lg">
-          <div className="p-2 border-b">
+        <div className="absolute z-20 mt-1.5 w-64 rounded-2xl shadow-xl aurora-surface-strong overflow-hidden">
+          <div className="p-2 border-b border-stone-200/60">
             <input
               ref={inputRef}
               type="text"
-              placeholder="Type to filter..."
+              placeholder="Type to filter…"
               value={query}
               onChange={(e) => setQuery(e.target.value)}
-              className="w-full px-2.5 py-1.5 text-sm border rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="aurora-input w-full text-sm"
             />
           </div>
           <div className="max-h-60 overflow-y-auto">
             <button
               onClick={() => { onChange(''); setOpen(false); setQuery(''); }}
-              className={`w-full text-left px-3 py-2 text-sm hover:bg-gray-50 ${!value ? 'bg-blue-50 text-blue-700 font-medium' : ''}`}
+              className={`w-full text-left px-3 py-2 text-sm transition-colors hover:bg-emerald-50/70 ${!value ? 'bg-emerald-50 text-emerald-800 font-medium' : 'text-stone-700'}`}
             >
-              All Locations
+              All locations
             </button>
             {filtered.map((loc) => (
               <button
                 key={loc.value}
                 onClick={() => { onChange(loc.value); setOpen(false); setQuery(''); }}
-                className={`w-full text-left px-3 py-2 text-sm hover:bg-gray-50 flex justify-between ${
-                  value === loc.value ? 'bg-blue-50 text-blue-700 font-medium' : ''
+                className={`w-full text-left px-3 py-2 text-sm transition-colors hover:bg-emerald-50/70 flex justify-between ${
+                  value === loc.value ? 'bg-emerald-50 text-emerald-800 font-medium' : 'text-stone-700'
                 }`}
               >
                 <span className="truncate">{loc.value}</span>
-                <span className="text-gray-400 text-xs ml-2 flex-shrink-0">{loc.count}</span>
+                <span className="text-stone-400 text-xs ml-2 flex-shrink-0 tabular-nums">{loc.count}</span>
               </button>
             ))}
             {filtered.length === 0 && (
-              <div className="px-3 py-4 text-sm text-gray-400 text-center">No matching locations</div>
+              <div className="px-3 py-4 text-sm text-stone-400 text-center italic">No matching locations</div>
             )}
           </div>
         </div>

--- a/web/src/components/agents/InventoryHealth.tsx
+++ b/web/src/components/agents/InventoryHealth.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
+import { BarChart, Bar, Cell, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
 
 const BUCKET_COLORS: Record<string, string> = {
-  '<7 days': '#10b981',
-  '7-30 days': '#3b82f6',
-  '30-90 days': '#f59e0b',
-  '90+ days': '#ef4444',
+  '<7 days': '#4a6b4a',
+  '7-30 days': '#6b8e6b',
+  '30-90 days': '#c9b896',
+  '90+ days': '#94a3b8',
 };
 
 interface InventoryHealthProps {
@@ -17,52 +17,48 @@ interface InventoryHealthProps {
   avgDom: number;
 }
 
+const TOOLTIP_STYLE = {
+  background: 'rgba(255,255,255,0.97)',
+  border: '1px solid #e7e5e4',
+  borderRadius: 12,
+  fontSize: 12,
+};
+
 export function InventoryHealth({ domDistribution, active, stale, removed, avgDom }: InventoryHealthProps) {
-  const chartData = domDistribution.map(d => ({
-    ...d,
-    fill: BUCKET_COLORS[d.bucket] || '#6b7280',
-  }));
-
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-      {/* DOM Chart */}
-      <div className="lg:col-span-2 bg-white rounded-lg border p-4">
-        <h3 className="text-sm font-semibold text-gray-700 mb-3">Days on Market</h3>
-        <div className="h-52">
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={chartData}>
-              <XAxis dataKey="bucket" tick={{ fontSize: 11 }} />
-              <YAxis tick={{ fontSize: 11 }} />
-              <Tooltip />
-              <Bar dataKey="count" radius={[4, 4, 0, 0]}>
-                {chartData.map((entry, i) => (
-                  <rect key={i} fill={entry.fill} />
-                ))}
-              </Bar>
-            </BarChart>
-          </ResponsiveContainer>
-        </div>
+    <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+      <div className="lg:col-span-2 aurora-surface rounded-2xl p-4">
+        <h3 className="text-[11px] uppercase tracking-wider text-stone-500 font-medium mb-2">Days on market</h3>
+        <ResponsiveContainer width="100%" height={210}>
+          <BarChart data={domDistribution}>
+            <XAxis dataKey="bucket" tick={{ fontSize: 11, fill: '#78716c' }} axisLine={false} tickLine={false} />
+            <YAxis tick={{ fontSize: 11, fill: '#78716c' }} axisLine={false} tickLine={false} />
+            <Tooltip contentStyle={TOOLTIP_STYLE} cursor={{ fill: 'rgba(107, 142, 107, 0.08)' }} />
+            <Bar dataKey="count" radius={[6, 6, 0, 0]}>
+              {domDistribution.map((entry, i) => (
+                <Cell key={i} fill={BUCKET_COLORS[entry.bucket] || '#78716c'} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
       </div>
 
-      {/* Status Cards */}
-      <div className="space-y-4">
-        <div className="bg-green-50 border border-green-200 rounded-lg p-4">
-          <p className="text-xs text-green-600 uppercase tracking-wide">Active</p>
-          <p className="text-2xl font-bold text-green-700">{active}</p>
-        </div>
-        <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
-          <p className="text-xs text-yellow-600 uppercase tracking-wide">Stale (&gt;30d)</p>
-          <p className="text-2xl font-bold text-yellow-700">{stale}</p>
-        </div>
-        <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-          <p className="text-xs text-red-600 uppercase tracking-wide">Removed</p>
-          <p className="text-2xl font-bold text-red-700">{removed}</p>
-        </div>
-        <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
-          <p className="text-xs text-gray-500 uppercase tracking-wide">Avg Days on Market</p>
-          <p className="text-2xl font-bold text-gray-700">{avgDom}</p>
-        </div>
+      <div className="grid grid-cols-2 lg:grid-cols-1 gap-3">
+        <StatusBox label="Active" value={active.toLocaleString()} accent="#4a6b4a" softBg="#ecf3ec" />
+        <StatusBox label="Stale (>30d)" value={stale.toLocaleString()} accent="#8b7949" softBg="#f5efe0" />
+        <StatusBox label="Removed" value={removed.toLocaleString()} accent="#9a3412" softBg="#fef3e6" />
+        <StatusBox label="Avg DOM" value={`${avgDom}d`} accent="#475569" softBg="#f1f5f9" />
       </div>
+    </div>
+  );
+}
+
+function StatusBox({ label, value, accent, softBg }: { label: string; value: string; accent: string; softBg: string }) {
+  return (
+    <div className="aurora-surface rounded-2xl px-4 py-3 relative overflow-hidden">
+      <div className="absolute -top-8 -right-8 w-20 h-20 rounded-full opacity-50 blur-2xl" style={{ background: softBg }} />
+      <p className="relative text-[10px] uppercase tracking-[0.2em] text-stone-500 font-medium">{label}</p>
+      <p className="relative font-serif text-2xl font-light mt-1.5 tabular-nums" style={{ color: accent }}>{value}</p>
     </div>
   );
 }

--- a/web/src/components/agents/MarketPosition.tsx
+++ b/web/src/components/agents/MarketPosition.tsx
@@ -19,86 +19,90 @@ interface MarketPositionProps {
   }[];
 }
 
+function compactPrice(p: number | null | undefined): string {
+  if (p == null) return '—';
+  if (p >= 1_000_000) return `$${(p / 1_000_000).toFixed(2)}M`;
+  if (p >= 1_000) return `$${(p / 1_000).toFixed(0)}K`;
+  return `$${Math.round(p)}`;
+}
+
 export function MarketPosition({ rank, totalSellers, areaPositions, competitors }: MarketPositionProps) {
   return (
     <div>
-      {/* Overall rank badge */}
       {rank && totalSellers && (
-        <div className="bg-gradient-to-r from-blue-600 to-blue-700 text-white rounded-lg p-4 mb-4 inline-block">
-          <p className="text-sm opacity-90">Overall Market Position</p>
-          <p className="text-2xl font-bold">Ranked #{rank} <span className="text-base font-normal opacity-75">of {totalSellers} sellers</span></p>
+        <div
+          className="rounded-2xl p-5 mb-4 inline-flex items-baseline gap-3 text-white shadow-md"
+          style={{ background: 'linear-gradient(135deg, #1a1a1a 0%, #4a6b4a 100%)' }}
+        >
+          <span className="text-[11px] uppercase tracking-[0.2em] opacity-70">Overall</span>
+          <span className="font-serif text-3xl font-light">#{rank}</span>
+          <span className="text-sm opacity-75">of {totalSellers.toLocaleString()} sellers</span>
         </div>
       )}
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {/* Area positions */}
-        <div className="bg-white rounded-lg border p-4">
-          <h3 className="text-sm font-semibold text-gray-700 mb-3">Position by Area</h3>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <div className="aurora-surface rounded-2xl p-4">
+          <h3 className="text-[11px] uppercase tracking-wider text-stone-500 font-medium mb-3">Position by area</h3>
           {areaPositions.length === 0 ? (
-            <p className="text-sm text-gray-400">No area data</p>
+            <p className="text-sm text-stone-400 italic">No area data</p>
           ) : (
-            <div className="overflow-x-auto">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="text-left text-xs text-gray-500 uppercase border-b">
-                    <th className="pb-2">Location</th>
-                    <th className="pb-2 text-right">Rank</th>
-                    <th className="pb-2 text-right">Share</th>
-                    <th className="pb-2 text-right">Listings</th>
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-[10px] uppercase tracking-wider text-stone-500 border-b border-stone-200/60">
+                  <th className="pb-2 font-medium">Location</th>
+                  <th className="pb-2 text-right font-medium">Rank</th>
+                  <th className="pb-2 text-right font-medium">Share</th>
+                  <th className="pb-2 text-right font-medium">Listings</th>
+                </tr>
+              </thead>
+              <tbody>
+                {areaPositions.map(area => (
+                  <tr key={area.location} className="border-b border-stone-200/40 last:border-0">
+                    <td className="py-2 text-stone-700 truncate max-w-[200px]">{area.location}</td>
+                    <td className="py-2 text-right">
+                      <span className={`font-medium tabular-nums ${area.rank <= 3 ? 'text-emerald-700' : 'text-stone-700'}`}>
+                        #{area.rank}
+                      </span>
+                    </td>
+                    <td className="py-2 text-right text-stone-600 tabular-nums">{area.marketShare}%</td>
+                    <td className="py-2 text-right text-stone-600 tabular-nums">{area.listingCount}</td>
                   </tr>
-                </thead>
-                <tbody>
-                  {areaPositions.map(area => (
-                    <tr key={area.location} className="border-b last:border-0">
-                      <td className="py-2 text-gray-700 truncate max-w-[200px]">{area.location}</td>
-                      <td className="py-2 text-right">
-                        <span className={`font-medium ${area.rank <= 3 ? 'text-blue-600' : 'text-gray-600'}`}>
-                          #{area.rank}
-                        </span>
-                      </td>
-                      <td className="py-2 text-right text-gray-600">{area.marketShare}%</td>
-                      <td className="py-2 text-right text-gray-600">{area.listingCount}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+                ))}
+              </tbody>
+            </table>
           )}
         </div>
 
-        {/* Top competitors */}
-        <div className="bg-white rounded-lg border p-4">
-          <h3 className="text-sm font-semibold text-gray-700 mb-3">Top Competitors</h3>
+        <div className="aurora-surface rounded-2xl p-4">
+          <h3 className="text-[11px] uppercase tracking-wider text-stone-500 font-medium mb-3">Top competitors</h3>
           {competitors.length === 0 ? (
-            <p className="text-sm text-gray-400">No competitor data</p>
+            <p className="text-sm text-stone-400 italic">No competitor data</p>
           ) : (
-            <div className="overflow-x-auto">
-              <table className="w-full text-sm">
-                <thead>
-                  <tr className="text-left text-xs text-gray-500 uppercase border-b">
-                    <th className="pb-2">Seller</th>
-                    <th className="pb-2 text-right">Overlap</th>
-                    <th className="pb-2 text-right">Avg Price</th>
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-[10px] uppercase tracking-wider text-stone-500 border-b border-stone-200/60">
+                  <th className="pb-2 font-medium">Seller</th>
+                  <th className="pb-2 text-right font-medium">Overlap</th>
+                  <th className="pb-2 text-right font-medium">Avg price</th>
+                </tr>
+              </thead>
+              <tbody>
+                {competitors.map(comp => (
+                  <tr key={comp.name} className="border-b border-stone-200/40 last:border-0">
+                    <td className="py-2">
+                      <Link
+                        href={`/agents/${encodeURIComponent(comp.name)}`}
+                        className="text-stone-900 underline-offset-4 hover:underline truncate block max-w-[200px]"
+                      >
+                        {comp.name}
+                      </Link>
+                    </td>
+                    <td className="py-2 text-right text-stone-600 tabular-nums">{comp.overlapListings}</td>
+                    <td className="py-2 text-right text-stone-600 tabular-nums">{compactPrice(comp.avgPrice)}</td>
                   </tr>
-                </thead>
-                <tbody>
-                  {competitors.map(comp => (
-                    <tr key={comp.name} className="border-b last:border-0">
-                      <td className="py-2">
-                        <Link
-                          href={`/agents/${encodeURIComponent(comp.name)}`}
-                          className="text-blue-600 hover:underline truncate block max-w-[200px]"
-                        >
-                          {comp.name}
-                        </Link>
-                      </td>
-                      <td className="py-2 text-right text-gray-600">{comp.overlapListings}</td>
-                      <td className="py-2 text-right text-gray-600">{formatPrice(comp.avgPrice)}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+                ))}
+              </tbody>
+            </table>
           )}
         </div>
       </div>

--- a/web/src/components/agents/PortfolioCharts.tsx
+++ b/web/src/components/agents/PortfolioCharts.tsx
@@ -2,17 +2,17 @@
 
 import {
   PieChart, Pie, Cell, BarChart, Bar, XAxis, YAxis, Tooltip,
-  ResponsiveContainer, Legend,
+  ResponsiveContainer,
 } from 'recharts';
 import type { PieLabelRenderProps } from 'recharts';
 
-const COLORS = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899', '#06b6d4', '#84cc16'];
+const COLORS = ['#4a6b4a', '#c9b896', '#94a3b8', '#c8dcc7', '#1a1a1a', '#ebe4cd', '#cfd8e3', '#78716c'];
 
 const CATEGORY_LABELS: Record<string, string> = {
-  sale: 'For Sale',
-  rental: 'For Rent',
+  sale: 'For sale',
+  rental: 'For rent',
   vacation: 'Vacation',
-  new_project: 'New Projects',
+  new_project: 'New projects',
 };
 
 const SUBCATEGORY_LABELS: Record<string, string> = {
@@ -35,6 +35,13 @@ interface PortfolioChartsProps {
   priceRanges: { range: string; count: number }[];
 }
 
+const TOOLTIP_STYLE = {
+  background: 'rgba(255,255,255,0.97)',
+  border: '1px solid #e7e5e4',
+  borderRadius: 12,
+  fontSize: 12,
+};
+
 export function PortfolioCharts({ categorySplit, subcategorySplit, priceRanges }: PortfolioChartsProps) {
   const categoryData = categorySplit.map(d => ({
     ...d,
@@ -47,62 +54,59 @@ export function PortfolioCharts({ categorySplit, subcategorySplit, priceRanges }
   }));
 
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-      {/* Category Pie */}
-      <div className="bg-white rounded-lg border p-4">
-        <h3 className="text-sm font-semibold text-gray-700 mb-3">Sale vs Rental</h3>
-        <div className="h-52">
-          <ResponsiveContainer width="100%" height="100%">
-            <PieChart>
-              <Pie
-                data={categoryData}
-                cx="50%"
-                cy="50%"
-                innerRadius={40}
-                outerRadius={70}
-                paddingAngle={3}
-                dataKey="value"
-                label={(props: PieLabelRenderProps) => `${props.name || ''} ${((Number(props.percent) || 0) * 100).toFixed(0)}%`}
-              >
-                {categoryData.map((_, i) => (
-                  <Cell key={i} fill={COLORS[i % COLORS.length]} />
-                ))}
-              </Pie>
-              <Tooltip />
-            </PieChart>
-          </ResponsiveContainer>
-        </div>
-      </div>
+    <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+      <ChartCard title="Sale vs rental">
+        <ResponsiveContainer width="100%" height={200}>
+          <PieChart margin={{ top: 4, right: 4, bottom: 4, left: 4 }}>
+            <Pie
+              data={categoryData}
+              cx="50%"
+              cy="50%"
+              innerRadius="48%"
+              outerRadius="80%"
+              paddingAngle={3}
+              dataKey="value"
+              label={(props: PieLabelRenderProps) => `${props.name || ''} ${((Number(props.percent) || 0) * 100).toFixed(0)}%`}
+            >
+              {categoryData.map((_, i) => (
+                <Cell key={i} fill={COLORS[i % COLORS.length]} stroke="none" />
+              ))}
+            </Pie>
+            <Tooltip contentStyle={TOOLTIP_STYLE} />
+          </PieChart>
+        </ResponsiveContainer>
+      </ChartCard>
 
-      {/* Subcategory Bar */}
-      <div className="bg-white rounded-lg border p-4">
-        <h3 className="text-sm font-semibold text-gray-700 mb-3">By Property Type</h3>
-        <div className="h-52">
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={subcategoryData} layout="vertical" margin={{ left: 60 }}>
-              <XAxis type="number" tick={{ fontSize: 11 }} />
-              <YAxis type="category" dataKey="name" tick={{ fontSize: 11 }} width={55} />
-              <Tooltip />
-              <Bar dataKey="value" fill="#3b82f6" radius={[0, 4, 4, 0]} />
-            </BarChart>
-          </ResponsiveContainer>
-        </div>
-      </div>
+      <ChartCard title="By property type">
+        <ResponsiveContainer width="100%" height={200}>
+          <BarChart data={subcategoryData} layout="vertical" margin={{ left: 60 }}>
+            <XAxis type="number" tick={{ fontSize: 11, fill: '#78716c' }} axisLine={false} tickLine={false} />
+            <YAxis type="category" dataKey="name" tick={{ fontSize: 11, fill: '#44403c' }} width={55} axisLine={false} tickLine={false} />
+            <Tooltip contentStyle={TOOLTIP_STYLE} cursor={{ fill: 'rgba(107, 142, 107, 0.08)' }} />
+            <Bar dataKey="value" fill="#6b8e6b" radius={[0, 6, 6, 0]} />
+          </BarChart>
+        </ResponsiveContainer>
+      </ChartCard>
 
-      {/* Price Range Bar */}
-      <div className="bg-white rounded-lg border p-4">
-        <h3 className="text-sm font-semibold text-gray-700 mb-3">Price Distribution</h3>
-        <div className="h-52">
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={priceRanges} margin={{ bottom: 10 }}>
-              <XAxis dataKey="range" tick={{ fontSize: 10 }} angle={-20} textAnchor="end" />
-              <YAxis tick={{ fontSize: 11 }} />
-              <Tooltip />
-              <Bar dataKey="count" fill="#10b981" radius={[4, 4, 0, 0]} />
-            </BarChart>
-          </ResponsiveContainer>
-        </div>
-      </div>
+      <ChartCard title="Price distribution">
+        <ResponsiveContainer width="100%" height={200}>
+          <BarChart data={priceRanges} margin={{ bottom: 10 }}>
+            <XAxis dataKey="range" tick={{ fontSize: 10, fill: '#78716c' }} angle={-20} textAnchor="end" axisLine={false} tickLine={false} />
+            <YAxis tick={{ fontSize: 11, fill: '#78716c' }} axisLine={false} tickLine={false} />
+            <Tooltip contentStyle={TOOLTIP_STYLE} cursor={{ fill: 'rgba(201, 184, 150, 0.15)' }} />
+            <Bar dataKey="count" fill="#c9b896" radius={[6, 6, 0, 0]} />
+          </BarChart>
+        </ResponsiveContainer>
+      </ChartCard>
+    </div>
+  );
+}
+
+function ChartCard({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="aurora-surface rounded-2xl p-4">
+      <h3 className="text-[11px] uppercase tracking-wider text-stone-500 font-medium mb-2">{title}</h3>
+      {children}
     </div>
   );
 }

--- a/web/src/components/agents/PricingIntelligence.tsx
+++ b/web/src/components/agents/PricingIntelligence.tsx
@@ -25,6 +25,13 @@ interface PricingIntelligenceProps {
   priceDrops: { count: number; avgPct: number };
 }
 
+const TOOLTIP_STYLE = {
+  background: 'rgba(255,255,255,0.97)',
+  border: '1px solid #e7e5e4',
+  borderRadius: 12,
+  fontSize: 12,
+};
+
 export function PricingIntelligence({ vsMarket, vsMarketSqm, priceDrops }: PricingIntelligenceProps) {
   const priceData = vsMarket.map(d => ({
     subcategory: SUBCATEGORY_LABELS[d.subcategory] || d.subcategory,
@@ -40,53 +47,54 @@ export function PricingIntelligence({ vsMarket, vsMarketSqm, priceDrops }: Prici
 
   return (
     <div>
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-4">
-        {/* Avg Price comparison */}
-        <div className="bg-white rounded-lg border p-4">
-          <h3 className="text-sm font-semibold text-gray-700 mb-3">Avg Price: Agent vs Market</h3>
-          <div className="h-56">
-            <ResponsiveContainer width="100%" height="100%">
-              <BarChart data={priceData} margin={{ bottom: 10 }}>
-                <XAxis dataKey="subcategory" tick={{ fontSize: 10 }} angle={-20} textAnchor="end" />
-                <YAxis tick={{ fontSize: 11 }} tickFormatter={v => `$${(v / 1000).toFixed(0)}k`} />
-                <Tooltip formatter={(value) => formatPrice(Number(value))} />
-                <Legend />
-                <Bar dataKey="Agent" fill="#3b82f6" radius={[4, 4, 0, 0]} />
-                <Bar dataKey="Market" fill="#9ca3af" radius={[4, 4, 0, 0]} />
-              </BarChart>
-            </ResponsiveContainer>
-          </div>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-4">
+        <div className="aurora-surface rounded-2xl p-4">
+          <h3 className="text-[11px] uppercase tracking-wider text-stone-500 font-medium mb-2">
+            Avg price · Agent vs Market
+          </h3>
+          <ResponsiveContainer width="100%" height={220}>
+            <BarChart data={priceData} margin={{ bottom: 10 }}>
+              <XAxis dataKey="subcategory" tick={{ fontSize: 10, fill: '#78716c' }} angle={-20} textAnchor="end" axisLine={false} tickLine={false} />
+              <YAxis tick={{ fontSize: 11, fill: '#78716c' }} tickFormatter={v => `$${(v / 1000).toFixed(0)}k`} axisLine={false} tickLine={false} />
+              <Tooltip contentStyle={TOOLTIP_STYLE} formatter={(value) => formatPrice(Number(value))} cursor={{ fill: 'rgba(107, 142, 107, 0.08)' }} />
+              <Legend wrapperStyle={{ fontSize: 12 }} />
+              <Bar dataKey="Agent" fill="#4a6b4a" radius={[6, 6, 0, 0]} />
+              <Bar dataKey="Market" fill="#c9b896" radius={[6, 6, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
         </div>
 
-        {/* Price per sqm comparison */}
-        <div className="bg-white rounded-lg border p-4">
-          <h3 className="text-sm font-semibold text-gray-700 mb-3">Avg $/m²: Agent vs Market</h3>
-          <div className="h-56">
-            {sqmData.length > 0 ? (
-              <ResponsiveContainer width="100%" height="100%">
-                <BarChart data={sqmData} margin={{ bottom: 10 }}>
-                  <XAxis dataKey="subcategory" tick={{ fontSize: 10 }} angle={-20} textAnchor="end" />
-                  <YAxis tick={{ fontSize: 11 }} tickFormatter={v => `$${v.toLocaleString()}`} />
-                  <Tooltip formatter={(value) => [`$${Number(value).toLocaleString()}/m²`, '']} />
-                  <Legend />
-                  <Bar dataKey="Agent" fill="#3b82f6" radius={[4, 4, 0, 0]} />
-                  <Bar dataKey="Market" fill="#9ca3af" radius={[4, 4, 0, 0]} />
-                </BarChart>
-              </ResponsiveContainer>
-            ) : (
-              <div className="flex items-center justify-center h-full text-gray-400 text-sm">
-                No price/m² data available
-              </div>
-            )}
-          </div>
+        <div className="aurora-surface rounded-2xl p-4">
+          <h3 className="text-[11px] uppercase tracking-wider text-stone-500 font-medium mb-2">
+            Avg $/m² · Agent vs Market
+          </h3>
+          {sqmData.length > 0 ? (
+            <ResponsiveContainer width="100%" height={220}>
+              <BarChart data={sqmData} margin={{ bottom: 10 }}>
+                <XAxis dataKey="subcategory" tick={{ fontSize: 10, fill: '#78716c' }} angle={-20} textAnchor="end" axisLine={false} tickLine={false} />
+                <YAxis tick={{ fontSize: 11, fill: '#78716c' }} tickFormatter={v => `$${v.toLocaleString()}`} axisLine={false} tickLine={false} />
+                <Tooltip contentStyle={TOOLTIP_STYLE} formatter={(value) => [`$${Number(value).toLocaleString()}/m²`, '']} cursor={{ fill: 'rgba(107, 142, 107, 0.08)' }} />
+                <Legend wrapperStyle={{ fontSize: 12 }} />
+                <Bar dataKey="Agent" fill="#4a6b4a" radius={[6, 6, 0, 0]} />
+                <Bar dataKey="Market" fill="#c9b896" radius={[6, 6, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          ) : (
+            <div className="flex items-center justify-center h-[220px] text-stone-400 text-sm italic">
+              No price/m² data available
+            </div>
+          )}
         </div>
       </div>
 
-      {/* Price drop stats */}
       {priceDrops.count > 0 && (
-        <div className="bg-amber-50 border border-amber-200 rounded-lg p-4">
-          <p className="text-sm text-amber-800">
-            <span className="font-semibold">{priceDrops.count} listing{priceDrops.count !== 1 ? 's' : ''}</span> had price reductions, averaging <span className="font-semibold">{priceDrops.avgPct}%</span> reduction.
+        <div className="aurora-surface rounded-2xl p-4 flex items-center gap-3">
+          <span className="aurora-chip aurora-chip-mint">↓ {priceDrops.avgPct}%</span>
+          <p className="text-sm text-stone-700">
+            <span className="font-medium text-stone-900">{priceDrops.count} listing{priceDrops.count !== 1 ? 's' : ''}</span>
+            {' '}had price reductions, averaging{' '}
+            <span className="font-medium text-stone-900">{priceDrops.avgPct}%</span>
+            {' '}off.
           </p>
         </div>
       )}

--- a/web/src/components/crawl-history/CrawlHistory.tsx
+++ b/web/src/components/crawl-history/CrawlHistory.tsx
@@ -40,7 +40,7 @@ interface CrawlHistoryResponse {
 }
 
 function formatDuration(secs: number | null): string {
-  if (secs === null || secs === undefined) return '-';
+  if (secs === null || secs === undefined) return '—';
   if (secs < 60) return `${secs}s`;
   if (secs < 3600) return `${Math.floor(secs / 60)}m ${secs % 60}s`;
   const h = Math.floor(secs / 3600);
@@ -62,29 +62,26 @@ function formatTime(iso: string): string {
 }
 
 function StatusBadge({ status }: { status: string }) {
-  const colors: Record<string, string> = {
-    completed: 'bg-green-100 text-green-800',
-    running: 'bg-yellow-100 text-yellow-800 animate-pulse',
-    cancelled: 'bg-orange-100 text-orange-800',
-    failed: 'bg-red-100 text-red-800',
+  const cls: Record<string, string> = {
+    completed: 'aurora-chip aurora-chip-mint',
+    running: 'aurora-chip aurora-chip-sand',
+    cancelled: 'aurora-chip aurora-chip-warn',
+    failed: 'aurora-chip aurora-chip-warn',
   };
   return (
-    <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${colors[status] || 'bg-gray-100 text-gray-800'}`}>
+    <span className={cls[status] || 'aurora-chip'}>
+      {status === 'running' && <span className="w-1.5 h-1.5 rounded-full bg-amber-600 animate-pulse" />}
       {status}
     </span>
   );
 }
 
 function TypeBadge({ type }: { type: string }) {
-  const styles: Record<string, string> = {
-    full: 'bg-purple-100 text-purple-800',
-    incremental: 'bg-blue-100 text-blue-800',
+  const cls: Record<string, string> = {
+    full: 'aurora-chip aurora-chip-slate capitalize',
+    incremental: 'aurora-chip capitalize',
   };
-  return (
-    <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium capitalize ${styles[type] || 'bg-gray-100 text-gray-800'}`}>
-      {type}
-    </span>
-  );
+  return <span className={cls[type] || 'aurora-chip capitalize'}>{type}</span>;
 }
 
 function DailyChart({ dailyStats }: { dailyStats: DailyStat[] }) {
@@ -93,30 +90,36 @@ function DailyChart({ dailyStats }: { dailyStats: DailyStat[] }) {
   const maxNew = Math.max(...dailyStats.map(d => d.total_new || 0), 1);
 
   return (
-    <div className="bg-white rounded-lg shadow p-6 mb-6">
-      <h2 className="text-lg font-semibold text-gray-900 mb-4">New Listings Per Day (Last 30 Days)</h2>
+    <div className="aurora-surface rounded-3xl p-6 mb-6">
+      <h2 className="font-serif text-2xl text-stone-900">
+        <span className="aurora-rule">Daily new listings</span>
+      </h2>
+      <p className="text-sm text-stone-500 mt-1 mb-4">Last 30 days</p>
       <div className="flex items-end gap-1 h-40">
         {dailyStats.map((day) => {
           const height = Math.max(((day.total_new || 0) / maxNew) * 100, 2);
           const date = new Date(day.day + 'T12:00:00');
           return (
             <div key={day.day} className="flex-1 flex flex-col items-center group relative">
-              <div className="hidden group-hover:block absolute -top-16 bg-gray-900 text-white text-xs rounded px-2 py-1 whitespace-nowrap z-10">
-                <div>{date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}</div>
-                <div>{day.total_new} new, {day.run_count} runs</div>
-                <div>Avg {formatDuration(Math.round(day.avg_duration))}</div>
+              <div className="hidden group-hover:block absolute -top-16 bg-stone-900 text-white text-xs rounded-lg px-2.5 py-1.5 whitespace-nowrap z-10 shadow-lg">
+                <div className="font-serif text-stone-50">{date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}</div>
+                <div className="text-stone-300">{day.total_new} new · {day.run_count} runs</div>
+                <div className="text-stone-400">Avg {formatDuration(Math.round(day.avg_duration))}</div>
               </div>
               <div
-                className="w-full bg-blue-500 rounded-t hover:bg-blue-600 transition-colors"
-                style={{ height: `${height}%` }}
+                className="w-full rounded-t transition-all"
+                style={{
+                  height: `${height}%`,
+                  background: 'linear-gradient(to top, #4a6b4a, #6b8e6b)',
+                }}
               />
             </div>
           );
         })}
       </div>
-      <div className="flex justify-between text-xs text-gray-500 mt-2">
-        <span>{dailyStats.length > 0 ? new Date(dailyStats[0].day + 'T12:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) : ''}</span>
-        <span>{dailyStats.length > 0 ? new Date(dailyStats[dailyStats.length - 1].day + 'T12:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) : ''}</span>
+      <div className="flex justify-between text-xs text-stone-500 mt-2">
+        <span>{new Date(dailyStats[0].day + 'T12:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}</span>
+        <span>{new Date(dailyStats[dailyStats.length - 1].day + 'T12:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}</span>
       </div>
     </div>
   );
@@ -131,18 +134,18 @@ function SummaryCards({ dailyStats }: { dailyStats: DailyStat[] }) {
     : 0;
 
   const cards = [
-    { label: 'Runs (30d)', value: totalRuns, color: 'text-blue-600' },
-    { label: 'New Listings (30d)', value: totalNew.toLocaleString(), color: 'text-green-600' },
-    { label: 'Avg Duration', value: formatDuration(avgDuration), color: 'text-purple-600' },
-    { label: 'Errors (30d)', value: totalErrors, color: totalErrors > 0 ? 'text-red-600' : 'text-gray-600' },
+    { label: 'Runs (30d)', value: totalRuns.toLocaleString() },
+    { label: 'New listings (30d)', value: totalNew.toLocaleString() },
+    { label: 'Avg duration', value: formatDuration(avgDuration) },
+    { label: 'Errors (30d)', value: totalErrors.toLocaleString() },
   ];
 
   return (
     <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
       {cards.map(c => (
-        <div key={c.label} className="bg-white rounded-lg shadow p-4">
-          <p className="text-sm text-gray-500">{c.label}</p>
-          <p className={`text-2xl font-bold ${c.color}`}>{c.value}</p>
+        <div key={c.label} className="aurora-surface rounded-2xl p-5">
+          <p className="text-[10px] uppercase tracking-[0.2em] text-stone-500 font-medium">{c.label}</p>
+          <p className="font-serif text-3xl font-light text-stone-900 mt-2 tabular-nums">{c.value}</p>
         </div>
       ))}
     </div>
@@ -169,13 +172,13 @@ export function CrawlHistory() {
   if (isLoading || !data) {
     return (
       <div className="space-y-4">
-        <div className="grid grid-cols-4 gap-4">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
           {Array.from({ length: 4 }).map((_, i) => (
-            <div key={i} className="animate-pulse bg-gray-200 rounded-lg h-20" />
+            <div key={i} className="animate-pulse aurora-surface h-24 rounded-2xl" />
           ))}
         </div>
-        <div className="animate-pulse bg-gray-200 rounded-lg h-48" />
-        <div className="animate-pulse bg-gray-200 rounded-lg h-96" />
+        <div className="animate-pulse aurora-surface rounded-3xl h-48" />
+        <div className="animate-pulse aurora-surface rounded-3xl h-96" />
       </div>
     );
   }
@@ -187,97 +190,85 @@ export function CrawlHistory() {
       <SummaryCards dailyStats={dailyStats} />
       <DailyChart dailyStats={dailyStats} />
 
-      <div className="bg-white rounded-lg shadow">
-        <div className="px-6 py-4 border-b border-gray-200">
-          <h2 className="text-lg font-semibold text-gray-900">All Crawl Runs</h2>
-          <p className="text-sm text-gray-500">{pagination.total} total runs</p>
+      <div className="aurora-surface rounded-3xl overflow-hidden">
+        <div className="px-6 py-4 border-b border-stone-200/60 flex items-center justify-between">
+          <div>
+            <h2 className="font-serif text-xl text-stone-900">All crawl runs</h2>
+            <p className="text-xs text-stone-500 mt-0.5">{pagination.total.toLocaleString()} total</p>
+          </div>
         </div>
 
         <div className="overflow-x-auto">
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
-              <tr>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">When</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Type</th>
-                <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase">Status</th>
-                <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Duration</th>
-                <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Found</th>
-                <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">New</th>
-                <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Updated</th>
-                <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Details</th>
-                <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase">Errors</th>
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-[11px] uppercase tracking-wider text-stone-500 border-b border-stone-200/60">
+                <th className="px-4 py-3 font-medium">When</th>
+                <th className="px-4 py-3 font-medium">Type</th>
+                <th className="px-4 py-3 font-medium">Status</th>
+                <th className="px-4 py-3 text-right font-medium">Duration</th>
+                <th className="px-4 py-3 text-right font-medium">Found</th>
+                <th className="px-4 py-3 text-right font-medium">New</th>
+                <th className="px-4 py-3 text-right font-medium">Updated</th>
+                <th className="px-4 py-3 text-right font-medium">Details</th>
+                <th className="px-4 py-3 text-right font-medium">Errors</th>
               </tr>
             </thead>
-            <tbody className="bg-white divide-y divide-gray-200">
+            <tbody>
               {runs.map((run) => (
                 <tr
                   key={run.id}
                   onClick={() => router.push(`/crawl-history/${run.id}`)}
-                  className={`hover:bg-gray-50 cursor-pointer ${run.status === 'running' ? 'bg-yellow-50 hover:bg-yellow-100' : ''}`}
+                  className={`border-b border-stone-200/40 last:border-0 hover:bg-white/50 cursor-pointer transition-colors ${run.status === 'running' ? 'bg-amber-50/40' : ''}`}
                 >
-                  <td className="px-4 py-3 text-sm text-gray-900 whitespace-nowrap">
-                    {formatTime(run.startedAt)}
-                  </td>
-                  <td className="px-4 py-3">
-                    <TypeBadge type={run.crawlType} />
-                  </td>
-                  <td className="px-4 py-3">
-                    <StatusBadge status={run.status} />
-                  </td>
-                  <td className="px-4 py-3 text-sm text-gray-600 text-right">
-                    {formatDuration(run.durationSecs)}
-                  </td>
-                  <td className="px-4 py-3 text-sm text-gray-900 text-right font-medium">
-                    {(run.listingsFound ?? 0).toLocaleString()}
-                  </td>
-                  <td className="px-4 py-3 text-sm text-right">
-                    <span className={run.listingsNew > 0 ? 'text-green-600 font-medium' : 'text-gray-400'}>
+                  <td className="px-4 py-3 text-stone-700 whitespace-nowrap">{formatTime(run.startedAt)}</td>
+                  <td className="px-4 py-3"><TypeBadge type={run.crawlType} /></td>
+                  <td className="px-4 py-3"><StatusBadge status={run.status} /></td>
+                  <td className="px-4 py-3 text-stone-600 text-right tabular-nums">{formatDuration(run.durationSecs)}</td>
+                  <td className="px-4 py-3 text-stone-900 text-right font-medium tabular-nums">{(run.listingsFound ?? 0).toLocaleString()}</td>
+                  <td className="px-4 py-3 text-right tabular-nums">
+                    <span className={run.listingsNew > 0 ? 'text-emerald-700 font-medium' : 'text-stone-400'}>
                       {run.listingsNew > 0 ? `+${run.listingsNew}` : '0'}
                     </span>
                   </td>
-                  <td className="px-4 py-3 text-sm text-right">
-                    <span className={run.listingsUpdated > 0 ? 'text-blue-600 font-medium' : 'text-gray-400'}>
+                  <td className="px-4 py-3 text-right tabular-nums">
+                    <span className={run.listingsUpdated > 0 ? 'text-stone-700 font-medium' : 'text-stone-400'}>
                       {run.listingsUpdated ?? 0}
                     </span>
                   </td>
-                  <td className="px-4 py-3 text-sm text-gray-600 text-right">
-                    {run.detailsCrawled ?? 0}
-                  </td>
-                  <td className="px-4 py-3 text-sm text-right">
-                    <span className={run.errorCount > 0 ? 'text-red-600 font-medium' : 'text-gray-400'}>
+                  <td className="px-4 py-3 text-stone-600 text-right tabular-nums">{run.detailsCrawled ?? 0}</td>
+                  <td className="px-4 py-3 text-right tabular-nums">
+                    <span className={run.errorCount > 0 ? 'text-rose-700 font-medium' : 'text-stone-400'}>
                       {run.errorCount}
                     </span>
                   </td>
                 </tr>
               ))}
               {runs.length === 0 && (
-                <tr>
-                  <td colSpan={9} className="px-4 py-8 text-center text-gray-500">No crawl runs found</td>
-                </tr>
+                <tr><td colSpan={9} className="px-4 py-12 text-center text-stone-500 italic">No crawl runs found</td></tr>
               )}
             </tbody>
           </table>
         </div>
 
         {pagination.totalPages > 1 && (
-          <div className="px-6 py-4 border-t border-gray-200 flex items-center justify-between">
-            <p className="text-sm text-gray-500">
-              Page {pagination.page} of {pagination.totalPages}
+          <div className="px-6 py-4 border-t border-stone-200/60 flex items-center justify-between">
+            <p className="text-xs text-stone-500">
+              Page <span className="font-serif text-stone-900 text-base">{pagination.page}</span> of {pagination.totalPages}
             </p>
             <div className="flex gap-2">
               <button
                 onClick={() => setPage(p => Math.max(1, p - 1))}
                 disabled={page <= 1}
-                className="px-3 py-1 text-sm rounded border border-gray-300 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="aurora-pill aurora-pill-ghost disabled:opacity-40 disabled:cursor-not-allowed"
               >
-                Previous
+                ← Previous
               </button>
               <button
                 onClick={() => setPage(p => Math.min(pagination.totalPages, p + 1))}
                 disabled={page >= pagination.totalPages}
-                className="px-3 py-1 text-sm rounded border border-gray-300 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="aurora-pill aurora-pill-ghost disabled:opacity-40 disabled:cursor-not-allowed"
               >
-                Next
+                Next →
               </button>
             </div>
           </div>

--- a/web/src/components/crawl-history/CrawlRunDetail.tsx
+++ b/web/src/components/crawl-history/CrawlRunDetail.tsx
@@ -184,22 +184,22 @@ export function CrawlRunDetail({ runId }: { runId: number }) {
   if (isLoading) {
     return (
       <div className="space-y-4">
-        <div className="animate-pulse bg-gray-200 rounded-lg h-16" />
+        <div className="animate-pulse aurora-surface h-16" />
         <div className="grid grid-cols-4 gap-4">
           {Array.from({ length: 4 }).map((_, i) => (
-            <div key={i} className="animate-pulse bg-gray-200 rounded-lg h-24" />
+            <div key={i} className="animate-pulse aurora-surface h-24" />
           ))}
         </div>
-        <div className="animate-pulse bg-gray-200 rounded-lg h-96" />
+        <div className="animate-pulse aurora-surface h-96" />
       </div>
     );
   }
 
   if (error || !data) {
     return (
-      <div className="text-center py-12 text-gray-500">
+      <div className="text-center py-12 text-stone-500 italic">
         <p>Failed to load crawl run data.</p>
-        <Link href="/crawl-history" className="text-blue-600 hover:underline mt-2 inline-block">Back to history</Link>
+        <Link href="/crawl-history" className="text-stone-900 underline-offset-4 hover:underline mt-2 inline-block">Back to history</Link>
       </div>
     );
   }
@@ -207,10 +207,10 @@ export function CrawlRunDetail({ runId }: { runId: number }) {
   const { crawlRun, stats, price, breakdowns, newListings, updatedListings, removedListings, errors: crawlErrors } = data;
   const isRunning = crawlRun.isRunning;
 
-  const tabs: { key: Tab; label: string; count: number; color?: string }[] = [
-    { key: 'new', label: 'New Listings', count: stats.newListings },
+  const tabs: { key: Tab; label: string; count: number }[] = [
+    { key: 'new', label: 'New listings', count: stats.newListings },
     { key: 'updated', label: 'Updated', count: stats.updatedListings },
-    { key: 'removed', label: 'Removed', count: stats.removed, color: 'text-red-600' },
+    { key: 'removed', label: 'Removed', count: stats.removed },
     { key: 'sellers', label: 'Sellers', count: breakdowns.sellers.length },
     { key: 'errors', label: 'Errors', count: stats.errors },
   ];
@@ -218,84 +218,88 @@ export function CrawlRunDetail({ runId }: { runId: number }) {
   return (
     <div>
       {/* Header */}
-      <div className="flex items-center justify-between mb-6">
-        <div className="flex items-center gap-4">
-          <Link href="/crawl-history" className="text-gray-400 hover:text-gray-600">
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" /></svg>
-          </Link>
-          <div>
-            <div className="flex items-center gap-3">
-              <h1 className="text-2xl font-bold text-gray-900">Crawl #{crawlRun.id}</h1>
-              <span className={`inline-flex items-center px-2.5 py-0.5 rounded text-xs font-medium ${
-                isRunning ? 'bg-yellow-100 text-yellow-800 animate-pulse' :
-                crawlRun.status === 'completed' ? 'bg-green-100 text-green-800' :
-                crawlRun.status === 'cancelled' ? 'bg-orange-100 text-orange-800' :
-                'bg-red-100 text-red-800'
-              }`}>
-                {isRunning && (
-                  <span className="relative flex h-2 w-2 mr-1.5">
-                    <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-yellow-500 opacity-75" />
-                    <span className="relative inline-flex rounded-full h-2 w-2 bg-yellow-500" />
-                  </span>
-                )}
-                {crawlRun.status}
+      <div className="flex flex-wrap items-start justify-between gap-3 mb-6">
+        <Link href="/crawl-history" className="aurora-pill aurora-pill-ghost">
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+          </svg>
+          Back to history
+        </Link>
+        {isRunning && (
+          <button
+            onClick={handleCancel}
+            disabled={cancelling}
+            className="aurora-pill aurora-pill-ghost text-rose-700 hover:text-rose-900"
+          >
+            {cancelling ? 'Cancelling…' : 'Cancel run'}
+          </button>
+        )}
+      </div>
+
+      <div className="mb-6">
+        <p className="text-[11px] uppercase tracking-[0.3em] text-stone-500 font-medium">Run detail</p>
+        <h1 className="font-serif text-4xl md:text-5xl font-light tracking-tight text-stone-900 mt-1.5">
+          Crawl <span className="italic">#{crawlRun.id}</span>
+        </h1>
+        <div className="flex flex-wrap items-center gap-1.5 mt-3">
+          <span className={
+            isRunning ? 'aurora-chip aurora-chip-sand' :
+            crawlRun.status === 'completed' ? 'aurora-chip aurora-chip-mint' :
+            'aurora-chip aurora-chip-warn'
+          }>
+            {isRunning && (
+              <span className="relative flex h-1.5 w-1.5">
+                <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-amber-500 opacity-70" />
+                <span className="relative inline-flex rounded-full h-1.5 w-1.5 bg-amber-600" />
               </span>
-              <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium capitalize ${
-                crawlRun.type === 'full' ? 'bg-purple-100 text-purple-800' : 'bg-blue-100 text-blue-800'
-              }`}>
-                {crawlRun.type}
-              </span>
-            </div>
-            <p className="text-sm text-gray-500 mt-0.5">
-              Started {new Date(crawlRun.startedAt).toLocaleString()}
-              {crawlRun.category && <> &middot; {crawlRun.category}{crawlRun.subcategory ? ` / ${crawlRun.subcategory}` : ''}</>}
-              {' '}&middot;{' '}
-              <ElapsedTimer startedAt={crawlRun.startedAt} isRunning={isRunning} />
-              {isRunning && <span className="text-yellow-600 ml-1">(polling every 5s)</span>}
-            </p>
-          </div>
-          {isRunning && (
-            <button
-              onClick={handleCancel}
-              disabled={cancelling}
-              className="px-3 py-1.5 text-sm bg-red-600 text-white rounded-md hover:bg-red-700 disabled:opacity-50 flex-shrink-0"
-            >
-              {cancelling ? 'Cancelling...' : 'Cancel Run'}
-            </button>
+            )}
+            {crawlRun.status}
+          </span>
+          <span className={crawlRun.type === 'full' ? 'aurora-chip aurora-chip-slate capitalize' : 'aurora-chip capitalize'}>
+            {crawlRun.type}
+          </span>
+          {crawlRun.category && (
+            <span className="aurora-chip">{crawlRun.category}{crawlRun.subcategory ? ` / ${crawlRun.subcategory}` : ''}</span>
           )}
         </div>
+        <p className="text-sm text-stone-500 mt-3">
+          Started {new Date(crawlRun.startedAt).toLocaleString()}
+          {' · '}
+          <ElapsedTimer startedAt={crawlRun.startedAt} isRunning={isRunning} />
+          {isRunning && <span className="text-amber-700 ml-1">(polling every 5s)</span>}
+        </p>
       </div>
 
       {/* Stats cards */}
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-        <StatCard label="New Listings" value={stats.newListings} color="text-green-600" />
-        <StatCard label="Details Crawled" value={stats.detailsCrawled} color="text-blue-600" />
-        <StatCard label="Updated" value={stats.updatedListings} color="text-indigo-600" />
-        <StatCard label="Errors" value={stats.errors} color={stats.errors > 0 ? 'text-red-600' : 'text-gray-400'} />
+        <StatCard label="New listings" value={stats.newListings} accent="#4a6b4a" />
+        <StatCard label="Details crawled" value={stats.detailsCrawled} accent="#475569" />
+        <StatCard label="Updated" value={stats.updatedListings} accent="#8b7949" />
+        <StatCard label="Errors" value={stats.errors} accent={stats.errors > 0 ? '#9a3412' : '#94a3b8'} />
       </div>
 
       {/* Price + Breakdowns row */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
         {price.total > 0 && (
-          <div className="bg-white rounded-lg shadow p-4">
-            <h3 className="text-xs font-medium text-gray-500 uppercase tracking-wide mb-3">Price Summary</h3>
+          <div className="aurora-surface rounded-2xl p-4">
+            <h3 className="text-[11px] uppercase tracking-wider text-stone-500 font-medium mb-3">Price Summary</h3>
             <div className="space-y-2 text-sm">
-              <div className="flex justify-between"><span className="text-gray-500">Avg Price</span><span className="font-medium">{formatPrice(price.avg)}</span></div>
-              <div className="flex justify-between"><span className="text-gray-500">Min</span><span className="font-medium">{formatPrice(price.min)}</span></div>
-              <div className="flex justify-between"><span className="text-gray-500">Max</span><span className="font-medium">{formatPrice(price.max)}</span></div>
-              <div className="flex justify-between"><span className="text-gray-500">With Price</span><span className="font-medium">{price.total}</span></div>
+              <div className="flex justify-between"><span className="text-stone-500">Avg price</span><span className="font-medium tabular-nums">{formatPrice(price.avg)}</span></div>
+              <div className="flex justify-between"><span className="text-stone-500">Min</span><span className="font-medium tabular-nums">{formatPrice(price.min)}</span></div>
+              <div className="flex justify-between"><span className="text-stone-500">Max</span><span className="font-medium tabular-nums">{formatPrice(price.max)}</span></div>
+              <div className="flex justify-between"><span className="text-stone-500">With price</span><span className="font-medium tabular-nums">{price.total}</span></div>
             </div>
           </div>
         )}
 
         {breakdowns.categories.length > 0 && (
-          <div className="bg-white rounded-lg shadow p-4">
-            <h3 className="text-xs font-medium text-gray-500 uppercase tracking-wide mb-3">Categories</h3>
+          <div className="aurora-surface rounded-2xl p-4">
+            <h3 className="text-[11px] uppercase tracking-wider text-stone-500 font-medium mb-3">Categories</h3>
             <div className="space-y-1.5 max-h-40 overflow-y-auto">
               {breakdowns.categories.map((c) => (
                 <div key={`${c.category}-${c.subcategory}`} className="flex justify-between text-sm">
-                  <span className="text-gray-700 truncate">{c.category} / {c.subcategory}</span>
-                  <span className="font-medium text-gray-900 ml-2">{c.count}</span>
+                  <span className="text-stone-700 truncate">{c.category} / {c.subcategory}</span>
+                  <span className="font-medium text-stone-900 ml-2 tabular-nums">{c.count}</span>
                 </div>
               ))}
             </div>
@@ -303,13 +307,13 @@ export function CrawlRunDetail({ runId }: { runId: number }) {
         )}
 
         {breakdowns.locations.length > 0 && (
-          <div className="bg-white rounded-lg shadow p-4">
-            <h3 className="text-xs font-medium text-gray-500 uppercase tracking-wide mb-3">Top Locations</h3>
+          <div className="aurora-surface rounded-2xl p-4">
+            <h3 className="text-[11px] uppercase tracking-wider text-stone-500 font-medium mb-3">Top Locations</h3>
             <div className="space-y-1.5 max-h-40 overflow-y-auto">
               {breakdowns.locations.map((l) => (
                 <div key={l.location} className="flex justify-between text-sm">
-                  <span className="text-gray-700 truncate">{l.location}</span>
-                  <span className="font-medium text-gray-900 ml-2">{l.count}</span>
+                  <span className="text-stone-700 truncate">{l.location}</span>
+                  <span className="font-medium text-stone-900 ml-2 tabular-nums">{l.count}</span>
                 </div>
               ))}
             </div>
@@ -318,8 +322,8 @@ export function CrawlRunDetail({ runId }: { runId: number }) {
       </div>
 
       {/* Tabs */}
-      <div className="bg-white rounded-lg shadow">
-        <div className="border-b border-gray-200">
+      <div className="aurora-surface rounded-2xl">
+        <div className="border-b border-stone-200/60">
           <nav className="flex -mb-px">
             {tabs.map((t) => (
               <button
@@ -327,13 +331,13 @@ export function CrawlRunDetail({ runId }: { runId: number }) {
                 onClick={() => setTab(t.key)}
                 className={`px-5 py-3 text-sm font-medium border-b-2 transition-colors ${
                   tab === t.key
-                    ? 'border-blue-500 text-blue-600'
-                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                    ? 'border-stone-900 text-stone-900'
+                    : 'border-transparent text-stone-500 hover:text-stone-900 hover:border-stone-300'
                 }`}
               >
                 {t.label}
-                <span className={`ml-1.5 px-1.5 py-0.5 rounded text-xs ${
-                  tab === t.key ? 'bg-blue-100 text-blue-600' : 'bg-gray-100 text-gray-500'
+                <span className={`ml-1.5 px-1.5 py-0.5 rounded-full text-[10px] tabular-nums ${
+                  tab === t.key ? 'bg-stone-900 text-white' : 'bg-stone-100 text-stone-500'
                 }`}>
                   {t.count}
                 </span>
@@ -354,11 +358,11 @@ export function CrawlRunDetail({ runId }: { runId: number }) {
   );
 }
 
-function StatCard({ label, value, color }: { label: string; value: number; color: string }) {
+function StatCard({ label, value, accent }: { label: string; value: number; accent: string }) {
   return (
-    <div className="bg-white rounded-lg shadow p-4">
-      <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">{label}</p>
-      <p className={`text-3xl font-bold mt-1 ${color}`}>{value.toLocaleString()}</p>
+    <div className="aurora-surface rounded-2xl p-5">
+      <p className="text-[10px] uppercase tracking-[0.2em] text-stone-500 font-medium">{label}</p>
+      <p className="font-serif text-3xl font-light mt-2 tabular-nums" style={{ color: accent }}>{value.toLocaleString()}</p>
     </div>
   );
 }
@@ -366,24 +370,24 @@ function StatCard({ label, value, color }: { label: string; value: number; color
 function PaginationControls({ pagination, onPageChange }: { pagination: Pagination; onPageChange: (p: number) => void }) {
   if (pagination.totalPages <= 1) return null;
   return (
-    <div className="flex items-center justify-between px-5 py-3 border-t border-gray-100">
-      <span className="text-xs text-gray-500">
-        Page {pagination.page} of {pagination.totalPages} ({pagination.total} total)
+    <div className="flex items-center justify-between px-5 py-3 border-t border-stone-200/40">
+      <span className="text-xs text-stone-500">
+        Page <span className="font-serif text-stone-900 text-base">{pagination.page}</span> of {pagination.totalPages} <span className="text-stone-400">({pagination.total.toLocaleString()} total)</span>
       </span>
       <div className="flex gap-2">
         <button
           onClick={() => onPageChange(pagination.page - 1)}
           disabled={pagination.page <= 1}
-          className="px-2.5 py-1 text-xs bg-white border rounded disabled:opacity-50 hover:bg-gray-50"
+          className="aurora-pill aurora-pill-ghost text-xs disabled:opacity-40 disabled:cursor-not-allowed"
         >
-          Prev
+          ← Prev
         </button>
         <button
           onClick={() => onPageChange(pagination.page + 1)}
           disabled={pagination.page >= pagination.totalPages}
-          className="px-2.5 py-1 text-xs bg-white border rounded disabled:opacity-50 hover:bg-gray-50"
+          className="aurora-pill aurora-pill-ghost text-xs disabled:opacity-40 disabled:cursor-not-allowed"
         >
-          Next
+          Next →
         </button>
       </div>
     </div>
@@ -392,43 +396,44 @@ function PaginationControls({ pagination, onPageChange }: { pagination: Paginati
 
 function NewListingsTab({ data, onPageChange }: { data: CrawlLiveData['newListings']; onPageChange: (p: number) => void }) {
   if (data.data.length === 0) {
-    return <div className="p-8 text-center text-gray-500">No new listings yet</div>;
+    return <div className="p-8 text-center text-stone-500 italic">No new listings yet</div>;
   }
 
   return (
     <>
-      <div className="divide-y divide-gray-100">
+      <div className="divide-y divide-stone-200/40">
         {data.data.map((l) => (
           <Link
             key={l.adId}
             href={`/listings/${l.adId}`}
-            className="flex items-center gap-4 px-5 py-3 hover:bg-gray-50 transition-colors"
+            className="flex items-center gap-4 px-5 py-3 hover:bg-white/50 transition-colors"
           >
-            <div className="w-16 h-12 flex-shrink-0 rounded bg-gray-100 overflow-hidden">
+            <div className="w-16 h-12 flex-shrink-0 rounded-lg bg-stone-100 overflow-hidden">
               {l.thumbnail ? (
+                // eslint-disable-next-line @next/next/no-img-element
                 <img src={l.thumbnail} alt="" className="w-full h-full object-cover" />
               ) : (
-                <div className="w-full h-full flex items-center justify-center text-gray-300">
+                <div className="w-full h-full flex items-center justify-center text-stone-300">
                   <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M2.25 15.75l5.159-5.159a2.25 2.25 0 013.182 0l5.159 5.159m-1.5-1.5l1.409-1.409a2.25 2.25 0 013.182 0l2.909 2.909M3.75 21h16.5A2.25 2.25 0 0022.5 18.75V5.25A2.25 2.25 0 0020.25 3H3.75A2.25 2.25 0 001.5 5.25v13.5A2.25 2.25 0 003.75 21z" /></svg>
                 </div>
               )}
             </div>
             <div className="flex-1 min-w-0">
-              <p className="text-sm font-medium text-gray-900 truncate">{l.title || l.adId}</p>
-              <div className="flex items-center gap-2 text-xs text-gray-500 mt-0.5">
+              <p className="text-sm font-medium text-stone-900 truncate">{l.title || l.adId}</p>
+              <div className="flex items-center gap-2 text-xs text-stone-500 mt-0.5">
                 <span>{l.subcategory}</span>
                 {l.location && <><span>&middot;</span><span>{l.location}</span></>}
                 {l.sellerName && <><span>&middot;</span><span>{l.sellerName}</span></>}
               </div>
             </div>
-            <div className="hidden md:flex items-center gap-3 text-xs text-gray-500 flex-shrink-0">
+            <div className="hidden md:flex items-center gap-3 text-xs text-stone-500 flex-shrink-0">
               {l.bedrooms !== null && <span>{l.bedrooms}bd</span>}
               {l.bathrooms !== null && <span>{l.bathrooms}ba</span>}
               {l.area !== null && <span>{l.area}m²</span>}
             </div>
             <div className="text-right flex-shrink-0">
-              <p className="text-sm font-semibold text-gray-900">{formatPrice(l.price)}</p>
-              <p className="text-xs text-gray-400">{formatTimeShort(l.firstSeenAt)}</p>
+              <p className="text-sm font-semibold text-stone-900 tabular-nums">{formatPrice(l.price)}</p>
+              <p className="text-xs text-stone-400">{formatTimeShort(l.firstSeenAt)}</p>
             </div>
           </Link>
         ))}
@@ -440,21 +445,21 @@ function NewListingsTab({ data, onPageChange }: { data: CrawlLiveData['newListin
 
 function UpdatedListingsTab({ data, onPageChange }: { data: CrawlLiveData['updatedListings']; onPageChange: (p: number) => void }) {
   if (data.data.length === 0) {
-    return <div className="p-8 text-center text-gray-500">No updated listings yet</div>;
+    return <div className="p-8 text-center text-stone-500 italic">No updated listings yet</div>;
   }
 
   return (
     <>
-      <div className="divide-y divide-gray-100">
+      <div className="divide-y divide-stone-200/40">
         {data.data.map((l) => (
           <Link
             key={l.adId}
             href={`/listings/${l.adId}`}
-            className="flex items-center gap-4 px-5 py-3 hover:bg-gray-50 transition-colors"
+            className="flex items-center gap-4 px-5 py-3 hover:bg-white/50 transition-colors"
           >
             <div className="flex-1 min-w-0">
-              <p className="text-sm font-medium text-gray-900 truncate">{l.title || l.adId}</p>
-              <div className="flex items-center gap-2 text-xs text-gray-500 mt-0.5">
+              <p className="text-sm font-medium text-stone-900 truncate">{l.title || l.adId}</p>
+              <div className="flex items-center gap-2 text-xs text-stone-500 mt-0.5">
                 <span>{l.subcategory}</span>
                 {l.location && <><span>&middot;</span><span>{l.location}</span></>}
                 {l.sellerName && <><span>&middot;</span><span>{l.sellerName}</span></>}
@@ -462,10 +467,10 @@ function UpdatedListingsTab({ data, onPageChange }: { data: CrawlLiveData['updat
             </div>
             <div className="flex items-center gap-2 flex-shrink-0">
               {l.detailCrawled && (
-                <span className="px-1.5 py-0.5 rounded text-xs bg-blue-100 text-blue-700">detail</span>
+                <span className="aurora-chip aurora-chip-slate">detail</span>
               )}
-              <span className="text-sm font-semibold text-gray-900">{formatPrice(l.price)}</span>
-              <span className="text-xs text-gray-400">{formatTimeShort(l.updatedAt)}</span>
+              <span className="text-sm font-semibold text-stone-900 tabular-nums">{formatPrice(l.price)}</span>
+              <span className="text-xs text-stone-400">{formatTimeShort(l.updatedAt)}</span>
             </div>
           </Link>
         ))}
@@ -477,29 +482,32 @@ function UpdatedListingsTab({ data, onPageChange }: { data: CrawlLiveData['updat
 
 function SellersTab({ sellers }: { sellers: CrawlLiveData['breakdowns']['sellers'] }) {
   if (sellers.length === 0) {
-    return <div className="p-8 text-center text-gray-500">No sellers found yet</div>;
+    return <div className="p-8 text-center text-stone-500 italic">No sellers found yet</div>;
   }
 
   const maxCount = Math.max(...sellers.map((s) => s.count), 1);
 
   return (
-    <div className="divide-y divide-gray-100">
+    <div className="divide-y divide-stone-200/40">
       {sellers.map((s) => (
         <Link
           key={s.name}
           href={`/agents/${encodeURIComponent(s.name)}`}
-          className="flex items-center gap-4 px-5 py-3 hover:bg-gray-50 transition-colors"
+          className="flex items-center gap-4 px-5 py-3 hover:bg-white/50 transition-colors"
         >
           <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium text-gray-900">{s.name}</p>
-            <div className="mt-1.5 h-1.5 bg-gray-100 rounded-full overflow-hidden">
+            <p className="text-sm font-medium text-stone-900">{s.name}</p>
+            <div className="mt-1.5 h-1.5 bg-stone-100 rounded-full overflow-hidden">
               <div
-                className="h-full bg-blue-500 rounded-full"
-                style={{ width: `${(s.count / maxCount) * 100}%` }}
+                className="h-full rounded-full"
+                style={{
+                  width: `${(s.count / maxCount) * 100}%`,
+                  background: 'linear-gradient(to right, #4a6b4a, #6b8e6b)',
+                }}
               />
             </div>
           </div>
-          <span className="text-sm font-semibold text-gray-900 flex-shrink-0">{s.count} listings</span>
+          <span className="text-sm font-medium text-stone-900 tabular-nums flex-shrink-0">{s.count}</span>
         </Link>
       ))}
     </div>
@@ -508,20 +516,20 @@ function SellersTab({ sellers }: { sellers: CrawlLiveData['breakdowns']['sellers
 
 function RemovedListingsTab({ data, onPageChange }: { data: CrawlLiveData['removedListings']; onPageChange: (p: number) => void }) {
   if (data.data.length === 0) {
-    return <div className="p-8 text-center text-gray-500">No removed listings detected</div>;
+    return <div className="p-8 text-center text-stone-500 italic">No removed listings detected</div>;
   }
 
   return (
     <>
-      <div className="divide-y divide-gray-100">
+      <div className="divide-y divide-stone-200/40">
         {data.data.map((l) => (
           <Link
             key={l.adId}
             href={`/listings/${l.adId}`}
-            className="flex items-center gap-4 px-5 py-3 hover:bg-red-50 transition-colors bg-red-50/30"
+            className="flex items-center gap-4 px-5 py-3 hover:bg-rose-50/40 transition-colors bg-rose-50/20"
           >
             <div className="flex-1 min-w-0">
-              <p className="text-sm font-medium text-red-700 truncate">{l.title || l.adId}</p>
+              <p className="text-sm font-medium text-rose-800 truncate">{l.title || l.adId}</p>
               <div className="flex items-center gap-2 text-xs text-gray-500 mt-0.5">
                 <span>{l.subcategory}</span>
                 {l.location && <><span>&middot;</span><span>{l.location}</span></>}
@@ -529,8 +537,8 @@ function RemovedListingsTab({ data, onPageChange }: { data: CrawlLiveData['remov
               </div>
             </div>
             <div className="text-right flex-shrink-0">
-              <p className="text-sm font-semibold text-gray-900">{formatPrice(l.price)}</p>
-              <p className="text-xs text-red-400">Removed {formatTimeShort(l.removedAt)}</p>
+              <p className="text-sm font-semibold text-stone-900 tabular-nums">{formatPrice(l.price)}</p>
+              <p className="text-xs text-rose-500">Removed {formatTimeShort(l.removedAt)}</p>
             </div>
           </Link>
         ))}
@@ -542,26 +550,26 @@ function RemovedListingsTab({ data, onPageChange }: { data: CrawlLiveData['remov
 
 function ErrorsTab({ data, onPageChange }: { data: CrawlLiveData['errors']; onPageChange: (p: number) => void }) {
   if (data.data.length === 0) {
-    return <div className="p-8 text-center text-gray-500">No errors</div>;
+    return <div className="p-8 text-center text-stone-500 italic">No errors</div>;
   }
 
   return (
     <>
-      <div className="divide-y divide-gray-100">
+      <div className="divide-y divide-stone-200/40">
         {data.data.map((e, i) => (
           <div key={i} className="px-5 py-3">
             <div className="flex items-center gap-2 mb-1">
-              <span className={`px-1.5 py-0.5 rounded text-xs font-medium ${
-                e.type === 'blocked' ? 'bg-red-100 text-red-700' :
-                e.type === 'http_error' ? 'bg-orange-100 text-orange-700' :
-                'bg-gray-100 text-gray-700'
-              }`}>
-                {e.type}{e.statusCode ? ` ${e.statusCode}` : ''}
+              <span className={
+                e.type === 'blocked' ? 'aurora-chip aurora-chip-warn' :
+                e.type === 'http_error' ? 'aurora-chip aurora-chip-warn' :
+                'aurora-chip aurora-chip-slate'
+              }>
+                {e.type}{e.statusCode ? ` · ${e.statusCode}` : ''}
               </span>
-              <span className="text-xs text-gray-400">{formatTimeShort(e.occurredAt)}</span>
+              <span className="text-xs text-stone-400">{formatTimeShort(e.occurredAt)}</span>
             </div>
-            <p className="text-sm text-gray-700 truncate">{e.url}</p>
-            {e.message && <p className="text-xs text-gray-500 truncate mt-0.5">{e.message}</p>}
+            <p className="text-sm text-stone-700 truncate">{e.url}</p>
+            {e.message && <p className="text-xs text-stone-500 truncate mt-0.5">{e.message}</p>}
           </div>
         ))}
       </div>

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -5,15 +5,35 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { UserButton, useUser } from '@stackframe/stack';
 
-const navItems = [
-  { href: '/', label: 'Dashboard', icon: 'M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6' },
-  { href: '/listings', label: 'Browse', icon: 'M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z' },
-  { href: '/map', label: 'Map', icon: 'M9 20l-5.447-2.724A1 1 0 013 16.382V5.618a1 1 0 011.447-.894L9 7m0 13l6-3m-6 3V7m6 10l4.553 2.276A1 1 0 0021 18.382V7.618a1 1 0 00-.553-.894L15 4m0 13V4m0 0L9 7' },
-  { href: '/pipeline', label: 'Pipeline', icon: 'M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2' },
-  { href: '/saved-searches', label: 'Saved Searches', icon: 'M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z' },
-  { href: '/agents', label: 'Agents', icon: 'M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z' },
-  { href: '/crawl-history', label: 'Crawl History', icon: 'M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15' },
+type NavItem = {
+  href: string;
+  label: string;
+  icon: React.ReactNode;
+};
+
+const Icon = ({ d }: { d: string }) => (
+  <svg className="w-[18px] h-[18px] shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.6}>
+    <path strokeLinecap="round" strokeLinejoin="round" d={d} />
+  </svg>
+);
+
+const navItems: NavItem[] = [
+  { href: '/', label: 'Dashboard',
+    icon: <Icon d="M3 12l9-9 9 9M5 10v10a1 1 0 001 1h4v-7h4v7h4a1 1 0 001-1V10" /> },
+  { href: '/listings', label: 'Browse',
+    icon: <Icon d="M21 21l-5-5m2-5a7 7 0 11-14 0 7 7 0 0114 0z" /> },
+  { href: '/map', label: 'Map',
+    icon: <Icon d="M9 20l-5-2.5V5l5 2.5m0 12.5l6-3m-6 3V7.5m6 9.5l5 2.5V8l-5-2.5m0 11.5V5.5" /> },
+  { href: '/pipeline', label: 'Pipeline',
+    icon: <Icon d="M4 6h16M4 12h10M4 18h6" /> },
+  { href: '/saved-searches', label: 'Saved Searches',
+    icon: <Icon d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-4-7 4V5z" /> },
+  { href: '/agents', label: 'Agents',
+    icon: <Icon d="M17 20h5v-2a3 3 0 00-5.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M16 7a4 4 0 11-8 0 4 4 0 018 0z" /> },
+  { href: '/crawl-history', label: 'Crawl History',
+    icon: <Icon d="M4 4v5h5M20 20v-5h-5M5 9a8 8 0 0114-3M19 15a8 8 0 01-14 3" /> },
 ];
+
 
 export function Sidebar() {
   const pathname = usePathname();
@@ -22,75 +42,129 @@ export function Sidebar() {
 
   return (
     <>
-      {/* Mobile hamburger button */}
+      {/* Mobile hamburger */}
       <button
         onClick={() => setOpen(true)}
-        className="md:hidden fixed top-3 left-3 z-50 p-2 rounded-md bg-gray-900 text-white shadow-lg"
+        className="md:hidden fixed top-3 left-3 z-50 p-2.5 rounded-full aurora-surface-strong shadow-md text-stone-700"
         aria-label="Open menu"
       >
-        <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.8}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
         </svg>
       </button>
 
       {/* Mobile overlay */}
       {open && (
         <div
-          className="md:hidden fixed inset-0 z-40 bg-black/50"
+          className="md:hidden fixed inset-0 z-40 bg-stone-900/30 backdrop-blur-sm"
           onClick={() => setOpen(false)}
         />
       )}
 
-      {/* Sidebar */}
       <aside
         className={`
-          fixed inset-y-0 left-0 z-50 w-56 bg-gray-900 text-gray-200 flex flex-col shrink-0
+          fixed inset-y-0 left-0 z-50 w-64 flex flex-col shrink-0
+          aurora-surface-strong
+          border-r border-stone-200/60
           transform transition-transform duration-200 ease-in-out
           ${open ? 'translate-x-0' : '-translate-x-full'}
           md:relative md:translate-x-0
         `}
+        style={{
+          background:
+            'linear-gradient(180deg, rgba(247,249,243,0.94) 0%, rgba(241,245,235,0.92) 100%)',
+        }}
       >
-        <div className="p-4 border-b border-gray-700 flex items-center justify-between">
-          <h1 className="text-lg font-bold text-white">E24 Tracker</h1>
+        {/* Decorative blur blobs */}
+        <div className="pointer-events-none absolute -top-10 -left-12 h-44 w-44 rounded-full bg-emerald-200/40 blur-3xl" />
+        <div className="pointer-events-none absolute bottom-20 -right-10 h-40 w-40 rounded-full bg-amber-100/50 blur-3xl" />
+
+        {/* Brand */}
+        <div className="relative px-5 pt-6 pb-5 flex items-center justify-between">
+          <Link href="/" className="flex items-center gap-2.5 group">
+            <span
+              className="w-9 h-9 rounded-2xl flex items-center justify-center text-white shadow-md group-hover:scale-105 transition-transform"
+              style={{ background: 'linear-gradient(135deg, #1a1a1a 0%, #4a6b4a 100%)' }}
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M3 12l9-9 9 9M5 10v10h14V10" />
+              </svg>
+            </span>
+            <div className="leading-tight">
+              <p className="font-serif text-lg text-stone-900 tracking-tight">
+                Encuentra<span className="italic text-stone-600">24</span>
+              </p>
+              <p className="text-[10px] uppercase tracking-[0.22em] text-stone-500">Property Desk</p>
+            </div>
+          </Link>
           <button
             onClick={() => setOpen(false)}
-            className="md:hidden p-1 rounded text-gray-400 hover:text-white"
+            className="md:hidden p-1 rounded text-stone-400 hover:text-stone-700"
             aria-label="Close menu"
           >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.8}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
             </svg>
           </button>
         </div>
-        <nav className="flex-1 p-2 space-y-1 overflow-y-auto">
-          {navItems.map(item => {
-            const active = item.href === '/' ? pathname === '/' : pathname.startsWith(item.href);
-            return (
-              <Link
-                key={item.href}
-                href={item.href}
-                onClick={() => setOpen(false)}
-                className={`flex items-center gap-3 px-3 py-2 rounded-md text-sm transition-colors ${
-                  active
-                    ? 'bg-gray-700 text-white'
-                    : 'text-gray-400 hover:text-white hover:bg-gray-800'
-                }`}
-              >
-                <svg className="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d={item.icon} />
-                </svg>
-                {item.label}
-              </Link>
-            );
-          })}
+
+        {/* Nav */}
+        <nav className="relative flex-1 px-3 pb-3 overflow-y-auto">
+          <p className="px-3 mb-1.5 text-[10px] uppercase tracking-[0.22em] text-stone-500/80 font-medium">
+            Workspace
+          </p>
+          <div className="space-y-0.5">
+            {navItems.map(item => {
+              const active = item.href === '/' ? pathname === '/' : pathname.startsWith(item.href);
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  onClick={() => setOpen(false)}
+                  className={`group relative flex items-center gap-3 px-3 py-2 rounded-xl text-sm transition-all
+                    ${active
+                      ? 'text-stone-900 font-medium'
+                      : 'text-stone-600 hover:text-stone-900'}`}
+                >
+                  {active && (
+                    <span
+                      className="absolute inset-0 rounded-xl"
+                      style={{
+                        background:
+                          'linear-gradient(110deg, rgba(255,255,255,0.95) 0%, rgba(245,249,242,0.95) 100%)',
+                        boxShadow:
+                          '0 1px 0 rgba(255,255,255,0.9) inset, 0 6px 16px -10px rgba(28,28,28,0.18)',
+                        border: '1px solid rgba(255,255,255,0.95)',
+                      }}
+                    />
+                  )}
+                  {!active && (
+                    <span className="absolute inset-0 rounded-xl opacity-0 group-hover:opacity-100 transition-opacity bg-white/40" />
+                  )}
+                  {active && (
+                    <span
+                      className="absolute left-1 top-1/2 -translate-y-1/2 h-5 w-[3px] rounded-full"
+                      style={{ background: 'linear-gradient(to bottom, #1a1a1a, #4a6b4a)' }}
+                    />
+                  )}
+                  <span className="relative">{item.icon}</span>
+                  <span className="relative">{item.label}</span>
+                </Link>
+              );
+            })}
+          </div>
+
         </nav>
+
+        {/* User card */}
         {user && (
-          <div className="p-3 border-t border-gray-700">
-            <div className="flex items-center gap-3">
-              <UserButton />
-              <div className="min-w-0 flex-1">
-                <p className="text-sm text-white truncate">{user.displayName || user.primaryEmail}</p>
-              </div>
+          <div className="relative m-3 rounded-2xl aurora-surface px-3 py-2.5 flex items-center gap-3">
+            <UserButton />
+            <div className="min-w-0 flex-1">
+              <p className="text-sm text-stone-900 font-medium truncate">
+                {user.displayName || user.primaryEmail?.split('@')[0]}
+              </p>
+              <p className="text-[11px] text-stone-500 truncate">{user.primaryEmail}</p>
             </div>
           </div>
         )}

--- a/web/src/components/listings/ImageGallery.tsx
+++ b/web/src/components/listings/ImageGallery.tsx
@@ -15,9 +15,10 @@ export function ImageGallery({ images, title }: ImageGalleryProps) {
     <>
       <div className="relative">
         <div
-          className="aspect-[16/9] bg-gray-100 rounded-lg overflow-hidden cursor-pointer"
+          className="aspect-[16/9] bg-stone-100 overflow-hidden cursor-pointer"
           onClick={() => setLightboxOpen(true)}
         >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
             src={images[selectedIndex]}
             alt={`${title} - Photo ${selectedIndex + 1}`}
@@ -28,36 +29,39 @@ export function ImageGallery({ images, title }: ImageGalleryProps) {
           <>
             <button
               onClick={() => setSelectedIndex(i => (i - 1 + images.length) % images.length)}
-              className="absolute left-2 top-1/2 -translate-y-1/2 bg-black/50 text-white p-1.5 rounded-full hover:bg-black/70"
+              className="absolute left-3 top-1/2 -translate-y-1/2 w-10 h-10 rounded-full bg-white/85 backdrop-blur text-stone-700 hover:bg-white shadow-md flex items-center justify-center"
+              aria-label="Previous"
             >
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
               </svg>
             </button>
             <button
               onClick={() => setSelectedIndex(i => (i + 1) % images.length)}
-              className="absolute right-2 top-1/2 -translate-y-1/2 bg-black/50 text-white p-1.5 rounded-full hover:bg-black/70"
+              className="absolute right-3 top-1/2 -translate-y-1/2 w-10 h-10 rounded-full bg-white/85 backdrop-blur text-stone-700 hover:bg-white shadow-md flex items-center justify-center"
+              aria-label="Next"
             >
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
               </svg>
             </button>
-            <span className="absolute bottom-2 right-2 bg-black/50 text-white text-xs px-2 py-1 rounded">
+            <span className="absolute bottom-3 right-3 bg-stone-900/80 backdrop-blur text-white text-xs px-2.5 py-1 rounded-full font-medium tabular-nums">
               {selectedIndex + 1} / {images.length}
             </span>
           </>
         )}
       </div>
       {images.length > 1 && (
-        <div className="flex gap-1 mt-2 overflow-x-auto pb-1">
+        <div className="flex gap-1.5 mt-3 overflow-x-auto px-1 pb-1">
           {images.slice(0, 20).map((img, i) => (
             <button
               key={i}
               onClick={() => setSelectedIndex(i)}
-              className={`shrink-0 w-16 h-12 rounded overflow-hidden border-2 ${
-                i === selectedIndex ? 'border-blue-500' : 'border-transparent'
+              className={`shrink-0 w-16 h-12 rounded-lg overflow-hidden transition-all ${
+                i === selectedIndex ? 'ring-2 ring-stone-900 ring-offset-2 ring-offset-transparent' : 'opacity-70 hover:opacity-100'
               }`}
             >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
               <img src={img} alt="" className="w-full h-full object-cover" />
             </button>
           ))}

--- a/web/src/components/listings/ListingCard.tsx
+++ b/web/src/components/listings/ListingCard.tsx
@@ -44,12 +44,10 @@ export function ListingCard({ listing }: ListingCardProps) {
   const loadedRef = useRef<Set<string>>(new Set());
   const preloadedRef = useRef(false);
 
-  // Set initial visible image
   useEffect(() => {
     if (images.length > 0) setVisibleSrc(images[0]);
   }, []);
 
-  // When imgIndex changes, show image only once loaded
   useEffect(() => {
     if (images.length === 0) return;
     const src = images[imgIndex];
@@ -65,7 +63,6 @@ export function ListingCard({ listing }: ListingCardProps) {
     }
   }, [imgIndex, images]);
 
-  // Preload all images on first hover
   const preloadAll = useCallback(() => {
     if (preloadedRef.current || images.length <= 1) return;
     preloadedRef.current = true;
@@ -107,40 +104,108 @@ export function ListingCard({ listing }: ListingCardProps) {
     setImgIndex(i => (i + 1) % images.length);
   }, [images.length]);
 
+  const placeText = [listing.location, listing.city, listing.province].filter(Boolean).join(', ');
+  const priceDropPct =
+    listing.oldPrice && listing.price && listing.oldPrice > listing.price
+      ? Math.round(((listing.oldPrice - listing.price) / listing.oldPrice) * 100)
+      : null;
+
   return (
-    <div className={`bg-white rounded-lg border overflow-hidden hover:shadow-md transition-shadow ${listing.removedAt ? 'border-red-300 opacity-75' : ''}`}>
-      <div className="relative aspect-[4/3] bg-gray-100 group" onMouseEnter={preloadAll}>
+    <article
+      className={`group relative rounded-3xl overflow-hidden transition-all duration-300
+        ${listing.removedAt ? 'opacity-70' : 'hover:-translate-y-1'}
+      `}
+      style={{
+        background: 'rgba(255,255,255,0.5)',
+        backdropFilter: 'saturate(140%) blur(12px)',
+        border: '1px solid rgba(255,255,255,0.85)',
+        boxShadow:
+          '0 1px 0 rgba(255,255,255,0.6) inset, 0 8px 24px -12px rgba(28,25,23,0.08)',
+      }}
+    >
+      <div className="relative aspect-[5/4] bg-stone-100 overflow-hidden" onMouseEnter={preloadAll}>
         <Link href={`/listings/${listing.adId}`} className="block w-full h-full">
           {visibleSrc ? (
+            // eslint-disable-next-line @next/next/no-img-element
             <img
               src={visibleSrc}
               alt={listing.title || ''}
-              className="w-full h-full object-cover"
+              className="w-full h-full object-cover transition-transform duration-700 group-hover:scale-[1.04]"
             />
           ) : (
-            <div className="w-full h-full flex items-center justify-center text-gray-400">
-              No image
+            <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-stone-100 to-stone-200">
+              <svg className="w-10 h-10 text-stone-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 16l4-4 4 4 8-8M4 4h16v16H4z" />
+              </svg>
             </div>
           )}
         </Link>
+
+        {/* Gradient bottom for legibility */}
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-black/40 to-transparent" />
+
+        {/* Top-left badges */}
+        <div className="absolute top-3 left-3 flex flex-col gap-1.5 z-10">
+          {listing.removedAt && (
+            <span className="aurora-chip aurora-chip-warn backdrop-blur-md">
+              Removed · {formatRelativeDate(listing.removedAt)}
+            </span>
+          )}
+          {!listing.removedAt && listing.featureLevel && listing.featureLevel !== 'basic' && (
+            <span className="aurora-chip aurora-chip-sand backdrop-blur-md capitalize">
+              ★ {listing.featureLevel}
+            </span>
+          )}
+          {priceDropPct != null && priceDropPct > 0 && (
+            <span className="aurora-chip aurora-chip-mint backdrop-blur-md">
+              ↓ {priceDropPct}% drop
+            </span>
+          )}
+        </div>
+
+        {/* Pipeline stage */}
+        {listing.pipelineStage && (
+          <span className="absolute top-3 right-3 aurora-chip aurora-chip-ink backdrop-blur-md capitalize z-10">
+            {listing.pipelineStage}
+          </span>
+        )}
+
+        {/* Favorite */}
+        <button
+          onClick={(e) => {
+            e.preventDefault();
+            toggleFavorite.mutate();
+          }}
+          className={`absolute z-10 ${listing.pipelineStage ? 'top-12' : 'top-3'} right-3 w-9 h-9 rounded-full flex items-center justify-center transition-all
+            ${listing.isFavorite
+              ? 'bg-stone-900 text-white shadow-lg shadow-stone-400/40'
+              : 'bg-white/85 backdrop-blur text-stone-700 hover:bg-white hover:text-stone-900'}`}
+          aria-label={listing.isFavorite ? 'Unfavorite' : 'Favorite'}
+        >
+          <svg className="w-4 h-4" fill={listing.isFavorite ? 'currentColor' : 'none'} stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+          </svg>
+        </button>
 
         {/* Carousel arrows */}
         {hasMultiple && (
           <>
             <button
               onClick={prev}
-              className="absolute left-1 top-1/2 -translate-y-1/2 bg-white/80 hover:bg-white text-gray-700 rounded-full p-1 opacity-0 group-hover:opacity-100 transition-opacity shadow"
+              className="absolute left-2 top-1/2 -translate-y-1/2 w-8 h-8 rounded-full bg-white/85 backdrop-blur text-stone-700 opacity-0 group-hover:opacity-100 hover:bg-white transition-all shadow-md flex items-center justify-center"
+              aria-label="Previous image"
             >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
               </svg>
             </button>
             <button
               onClick={next}
-              className="absolute right-1 top-1/2 -translate-y-1/2 bg-white/80 hover:bg-white text-gray-700 rounded-full p-1 opacity-0 group-hover:opacity-100 transition-opacity shadow"
+              className="absolute right-2 top-1/2 -translate-y-1/2 w-8 h-8 rounded-full bg-white/85 backdrop-blur text-stone-700 opacity-0 group-hover:opacity-100 hover:bg-white transition-all shadow-md flex items-center justify-center"
+              aria-label="Next image"
             >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
               </svg>
             </button>
           </>
@@ -148,120 +213,108 @@ export function ListingCard({ listing }: ListingCardProps) {
 
         {/* Dot indicators */}
         {hasMultiple && (
-          <div className="absolute bottom-2 left-1/2 -translate-x-1/2 flex gap-1">
+          <div className="absolute bottom-2.5 left-1/2 -translate-x-1/2 flex gap-1 z-10">
             {images.slice(0, 7).map((_, i) => (
               <span
                 key={i}
-                className={`w-1.5 h-1.5 rounded-full transition-colors ${
-                  i === imgIndex ? 'bg-white' : 'bg-white/50'
-                }`}
+                className={`h-1 rounded-full transition-all ${i === imgIndex ? 'w-4 bg-white' : 'w-1 bg-white/60'}`}
               />
             ))}
             {images.length > 7 && (
-              <span className="text-white text-[8px] leading-none self-center">+{images.length - 7}</span>
+              <span className="text-white/80 text-[10px] leading-none self-center ml-0.5">+{images.length - 7}</span>
             )}
           </div>
         )}
 
-        {/* Image count badge */}
-        {listing.imageCount && listing.imageCount > 1 && (
-          <span className="absolute bottom-2 right-2 bg-black/60 text-white text-xs px-1.5 py-0.5 rounded">
-            {imgIndex + 1}/{listing.imageCount}
-          </span>
-        )}
-
-        {/* Removed badge */}
-        {listing.removedAt && (
-          <span className="absolute top-2 left-2 bg-red-500 text-white text-xs font-medium px-1.5 py-0.5 rounded z-10">
-            Removed {formatRelativeDate(listing.removedAt)}
-          </span>
-        )}
-
-        {/* Feature level badge */}
-        {!listing.removedAt && listing.featureLevel && listing.featureLevel !== 'basic' && (
-          <span className="absolute top-2 left-2 bg-yellow-400 text-yellow-900 text-xs font-medium px-1.5 py-0.5 rounded">
-            {listing.featureLevel}
-          </span>
-        )}
-
-        {/* Pipeline badge */}
-        {listing.pipelineStage && (
-          <span className="absolute top-2 right-2 bg-blue-500 text-white text-xs px-1.5 py-0.5 rounded">
-            {listing.pipelineStage}
-          </span>
-        )}
+        {/* Bottom-right time */}
+        <div className="absolute bottom-3 right-3 text-[10px] text-white/90 font-medium tracking-wide z-10">
+          {formatRelativeDate(listing.publishedAt || listing.firstSeenAt)}
+        </div>
       </div>
 
-      <div className="p-3">
-        <div className="flex items-start justify-between gap-2">
-          <div className="min-w-0">
-            <p className="text-lg font-bold text-gray-900">
-              {formatPrice(listing.price, listing.currency || 'USD')}
-              {listing.oldPrice && listing.oldPrice > (listing.price || 0) && (
-                <span className="ml-2 text-sm line-through text-gray-400 font-normal">
-                  {formatPrice(listing.oldPrice)}
-                </span>
-              )}
+      <Link href={`/listings/${listing.adId}`} className="block px-5 py-4">
+        <div className="flex items-baseline justify-between gap-3">
+          <p className="font-serif text-2xl text-stone-900 tracking-tight">
+            {formatPrice(listing.price, listing.currency || 'USD')}
+          </p>
+          {listing.oldPrice && listing.oldPrice > (listing.price || 0) && (
+            <p className="text-xs text-stone-400 line-through">
+              {formatPrice(listing.oldPrice)}
             </p>
-          </div>
-          <button
-            onClick={(e) => {
-              e.preventDefault();
-              toggleFavorite.mutate();
-            }}
-            className={`shrink-0 p-1 rounded-full hover:bg-gray-100 ${listing.isFavorite ? 'text-red-500' : 'text-gray-300'}`}
-          >
-            <svg className="w-5 h-5" fill={listing.isFavorite ? 'currentColor' : 'none'} stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
-            </svg>
-          </button>
+          )}
         </div>
-        <Link href={`/listings/${listing.adId}`}>
-          <p className="text-sm text-gray-700 mt-1 truncate">{listing.title}</p>
-          <p className="text-xs text-gray-500 mt-0.5">{[listing.location, listing.city, listing.province].filter(Boolean).join(', ')}</p>
-          {(listing.agentName || listing.sellerName) && (
-            <p className="text-xs text-gray-500 mt-1 truncate flex items-center gap-1">
-              <span>
+
+        <p className="mt-1 text-sm text-stone-700 line-clamp-1 font-medium">{listing.title || '—'}</p>
+        <p className="text-xs text-stone-500 mt-0.5 truncate">{placeText || '—'}</p>
+
+        {/* Specs */}
+        <div className="mt-3 flex flex-wrap items-center gap-3 text-xs text-stone-600">
+          {listing.bedrooms != null && (
+            <span className="flex items-center gap-1">
+              <svg className="w-3.5 h-3.5 text-stone-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.6}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M3 10v8a1 1 0 001 1h16a1 1 0 001-1v-8M3 10V6a2 2 0 012-2h14a2 2 0 012 2v4M3 10h18M7 14h4M13 14h4" />
+              </svg>
+              {listing.bedrooms} bd
+            </span>
+          )}
+          {listing.bathrooms != null && (
+            <span className="flex items-center gap-1">
+              <svg className="w-3.5 h-3.5 text-stone-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.6}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M5 12V5a2 2 0 012-2h2v3M3 12h18v3a4 4 0 01-4 4H7a4 4 0 01-4-4v-3z" />
+              </svg>
+              {listing.bathrooms} ba
+            </span>
+          )}
+          {listing.builtAreaSqm != null && (
+            <span className="flex items-center gap-1">
+              <svg className="w-3.5 h-3.5 text-stone-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.6}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M4 4h6v6H4zM14 4h6v6h-6zM4 14h6v6H4zM14 14h6v6h-6z" />
+              </svg>
+              {formatArea(listing.builtAreaSqm)}
+            </span>
+          )}
+          {listing.parking != null && listing.parking > 0 && (
+            <span className="flex items-center gap-1">
+              <svg className="w-3.5 h-3.5 text-stone-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.6}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M5 17h14M5 17V7l3-3h8l3 3v10M5 17H3m16 0h2M8 14h2m4 0h2" />
+              </svg>
+              {listing.parking}
+            </span>
+          )}
+          {listing.favoritesCount != null && listing.favoritesCount > 0 && (
+            <span className="ml-auto flex items-center gap-1 text-stone-400">
+              <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+              </svg>
+              {listing.favoritesCount}
+            </span>
+          )}
+        </div>
+
+        {/* Seller */}
+        {(listing.agentName || listing.sellerName) && (
+          <div className="mt-3 pt-3 border-t border-stone-200/60 flex items-center gap-2">
+            <span
+              className="w-6 h-6 rounded-full flex items-center justify-center text-[10px] font-medium text-stone-700 shrink-0"
+              style={{ background: 'linear-gradient(135deg, #ecf3ec, #ebe4cd)' }}
+            >
+              {(listing.agentName || listing.sellerName || '').charAt(0).toUpperCase()}
+            </span>
+            <p className="text-xs text-stone-600 truncate flex items-center gap-1">
+              <span className="truncate">
                 {listing.agentName && listing.sellerName
-                  ? `${listing.agentName} \u00B7 ${listing.sellerName}`
+                  ? `${listing.agentName} · ${listing.sellerName}`
                   : listing.agentName || listing.sellerName}
               </span>
               {listing.sellerVerified && (
-                <svg className="w-3 h-3 text-blue-500 shrink-0" fill="currentColor" viewBox="0 0 20 20">
+                <svg className="w-3.5 h-3.5 text-sky-500 shrink-0" fill="currentColor" viewBox="0 0 20 20">
                   <path fillRule="evenodd" d="M6.267 3.455a3.066 3.066 0 001.745-.723 3.066 3.066 0 013.976 0 3.066 3.066 0 001.745.723 3.066 3.066 0 012.812 2.812c.051.643.304 1.254.723 1.745a3.066 3.066 0 010 3.976 3.066 3.066 0 00-.723 1.745 3.066 3.066 0 01-2.812 2.812 3.066 3.066 0 00-1.745.723 3.066 3.066 0 01-3.976 0 3.066 3.066 0 00-1.745-.723 3.066 3.066 0 01-2.812-2.812 3.066 3.066 0 00-.723-1.745 3.066 3.066 0 010-3.976 3.066 3.066 0 00.723-1.745 3.066 3.066 0 012.812-2.812zm7.44 5.252a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
                 </svg>
               )}
             </p>
-          )}
-          <div className="flex items-center gap-3 mt-2 text-xs text-gray-600">
-            {listing.bedrooms != null && (
-              <span>{listing.bedrooms} bd</span>
-            )}
-            {listing.bathrooms != null && (
-              <span>{listing.bathrooms} ba</span>
-            )}
-            {listing.builtAreaSqm != null && (
-              <span>{formatArea(listing.builtAreaSqm)}</span>
-            )}
-            {listing.parking != null && listing.parking > 0 && (
-              <span>{listing.parking} pk</span>
-            )}
           </div>
-          <div className="flex items-center justify-between mt-2">
-            <p className="text-xs text-gray-400">
-              {formatRelativeDate(listing.publishedAt || listing.firstSeenAt)}
-            </p>
-            {listing.favoritesCount != null && listing.favoritesCount > 0 && (
-              <span className="text-xs text-gray-400 flex items-center gap-0.5">
-                <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24">
-                  <path d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
-                </svg>
-                {listing.favoritesCount}
-              </span>
-            )}
-          </div>
-        </Link>
-      </div>
-    </div>
+        )}
+      </Link>
+    </article>
   );
 }

--- a/web/src/components/listings/ListingDetail.tsx
+++ b/web/src/components/listings/ListingDetail.tsx
@@ -10,7 +10,7 @@ import { PriceHistoryChart } from './PriceHistoryChart';
 
 const DetailMap = dynamic(
   () => import('./DetailMap').then(m => ({ default: m.DetailMap })),
-  { ssr: false, loading: () => <div className="w-full h-64 bg-gray-100 animate-pulse rounded-lg" /> }
+  { ssr: false, loading: () => <div className="w-full h-64 rounded-2xl aurora-surface animate-pulse" /> }
 );
 
 interface PriceHistoryEntry {
@@ -134,86 +134,120 @@ export function ListingDetail({ listing, priceHistory, notes }: ListingDetailPro
     setNoteText('');
   }
 
+  const placeText = [listing.location, listing.city, listing.province].filter(Boolean).join(' · ');
+  const priceDropPct =
+    listing.oldPrice && listing.price && listing.oldPrice > listing.price
+      ? Math.round(((listing.oldPrice - listing.price) / listing.oldPrice) * 100)
+      : null;
+
   return (
-    <div className="p-6 max-w-5xl mx-auto">
-      <div className="mb-4">
-        <button onClick={() => router.back()} className="text-sm text-blue-600 hover:underline">
-          &larr; Back to listings
-        </button>
-      </div>
+    <div className="px-6 md:px-10 py-8 max-w-5xl mx-auto">
+      {/* Back */}
+      <button
+        onClick={() => router.back()}
+        className="aurora-pill aurora-pill-ghost mb-5"
+      >
+        <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M15 19l-7-7 7-7" />
+        </svg>
+        Back to listings
+      </button>
 
       {/* Image Gallery */}
       {listing.images && listing.images.length > 0 && (
-        <ImageGallery images={listing.images} title={listing.title || ''} />
+        <div className="rounded-3xl overflow-hidden aurora-surface">
+          <ImageGallery images={listing.images} title={listing.title || ''} />
+        </div>
       )}
 
       {/* Header */}
-      <div className="flex items-start justify-between mt-4 gap-4">
-        <div>
-          <h1 className="text-2xl font-bold text-gray-900">
-            {formatPrice(listing.price, listing.currency || 'USD')}
+      <div className="mt-6 flex flex-wrap items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <p className="text-[11px] uppercase tracking-[0.3em] text-stone-500 font-medium capitalize">
+            {listing.category} · {listing.subcategory.replace(/-/g, ' ')}
+          </p>
+          <div className="flex flex-wrap items-baseline gap-3 mt-2">
+            <h1 className="font-serif text-4xl md:text-5xl font-light tracking-tight text-stone-900">
+              {formatPrice(listing.price, listing.currency || 'USD')}
+            </h1>
             {listing.oldPrice && listing.oldPrice > (listing.price || 0) && (
-              <span className="ml-2 text-lg line-through text-gray-400 font-normal">
+              <span className="text-lg line-through text-stone-400">
                 {formatPrice(listing.oldPrice)}
               </span>
             )}
-          </h1>
-          <p className="text-gray-700 mt-1">{listing.title}</p>
-          <p className="text-sm text-gray-500 mt-0.5">
-            {[listing.location, listing.city, listing.province].filter(Boolean).join(', ')}
-          </p>
+            {priceDropPct != null && (
+              <span className="aurora-chip aurora-chip-mint">↓ {priceDropPct}%</span>
+            )}
+            {listing.featureLevel && listing.featureLevel !== 'basic' && (
+              <span className="aurora-chip aurora-chip-sand capitalize">★ {listing.featureLevel}</span>
+            )}
+          </div>
+          <p className="text-stone-700 mt-2 text-lg">{listing.title || '—'}</p>
+          {placeText && <p className="text-sm text-stone-500 mt-1">{placeText}</p>}
+          {(listing.pricePerSqmConstruction || listing.pricePerSqmLand) && (
+            <div className="flex flex-wrap gap-2 mt-3">
+              {listing.pricePerSqmConstruction != null && (
+                <span className="aurora-chip aurora-chip-slate">
+                  ${Math.round(listing.pricePerSqmConstruction).toLocaleString()}/m² built
+                </span>
+              )}
+              {listing.pricePerSqmLand != null && (
+                <span className="aurora-chip aurora-chip-sand">
+                  ${Math.round(listing.pricePerSqmLand).toLocaleString()}/m² land
+                </span>
+              )}
+            </div>
+          )}
         </div>
         <div className="flex items-center gap-2 shrink-0">
           <button
             onClick={toggleFavorite}
-            className={`p-2 rounded-full border ${isFav ? 'text-red-500 border-red-200 bg-red-50' : 'text-gray-400 border-gray-200 hover:bg-gray-50'}`}
+            aria-label={isFav ? 'Unfavorite' : 'Favorite'}
+            className={`aurora-pill ${isFav ? 'aurora-pill-primary' : 'aurora-pill-ghost'}`}
           >
-            <svg className="w-5 h-5" fill={isFav ? 'currentColor' : 'none'} stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
+            <svg className="w-3.5 h-3.5" fill={isFav ? 'currentColor' : 'none'} stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
             </svg>
+            {isFav ? 'Saved' : 'Save'}
           </button>
           <a
             href={listing.url}
             target="_blank"
             rel="noopener noreferrer"
-            className="px-3 py-1.5 text-sm border rounded hover:bg-gray-50"
+            className="aurora-pill aurora-pill-ghost"
           >
             View on E24
+            <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M14 5h5m0 0v5m0-5L10 14M5 5v14h14" />
+            </svg>
           </a>
         </div>
       </div>
 
-      {/* Specs Grid */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mt-4">
-        <Spec label="Bedrooms" value={listing.bedrooms} />
-        <Spec label="Bathrooms" value={listing.bathrooms} />
-        <Spec label="Parking" value={listing.parking} />
-        <Spec label="Built Area" value={listing.builtAreaSqm ? formatArea(listing.builtAreaSqm) : null} />
-        <Spec label="Land Area" value={listing.landAreaSqm ? formatArea(listing.landAreaSqm) : null} />
-        <Spec label="Year Built" value={listing.yearBuilt} />
-        <Spec label="Levels" value={listing.levels} />
-        <Spec label="Floor" value={listing.floorNumber} />
+      {/* Specs */}
+      <div className="mt-6 grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <Spec label="Bedrooms" value={listing.bedrooms} icon="bd" />
+        <Spec label="Bathrooms" value={listing.bathrooms} icon="ba" />
+        <Spec label="Parking" value={listing.parking} icon="p" />
+        <Spec label="Built Area" value={listing.builtAreaSqm ? formatArea(listing.builtAreaSqm) : null} icon="a" />
+        <Spec label="Land Area" value={listing.landAreaSqm ? formatArea(listing.landAreaSqm) : null} icon="l" />
+        <Spec label="Year Built" value={listing.yearBuilt} icon="y" />
+        <Spec label="Levels" value={listing.levels} icon="lv" />
+        <Spec label="Floor" value={listing.floorNumber} icon="f" />
       </div>
 
-      {/* Price per m² */}
-      {(listing.pricePerSqmConstruction || listing.pricePerSqmLand) && (
-        <div className="flex gap-4 mt-3 text-sm text-gray-600">
-          {listing.pricePerSqmConstruction && (
-            <span>${listing.pricePerSqmConstruction.toLocaleString()}/m² built</span>
-          )}
-          {listing.pricePerSqmLand && (
-            <span>${listing.pricePerSqmLand.toLocaleString()}/m² land</span>
-          )}
-        </div>
-      )}
-
       {/* Pipeline Stage */}
-      <div className="mt-4 flex items-center gap-2">
-        <label className="text-sm text-gray-600">Pipeline:</label>
+      <div className="mt-6 aurora-surface rounded-2xl px-5 py-4 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <p className="text-[11px] uppercase tracking-wider text-stone-500 font-medium">Your pipeline</p>
+          <p className="font-serif text-lg text-stone-900 mt-0.5">
+            {stage ? PIPELINE_STAGE_LABELS[stage as keyof typeof PIPELINE_STAGE_LABELS] || stage : 'Not in pipeline'}
+          </p>
+        </div>
         <select
           value={stage || ''}
           onChange={e => updateStage(e.target.value)}
-          className="px-2 py-1 text-sm border rounded bg-white"
+          className="aurora-input"
         >
           <option value="">Not in pipeline</option>
           {PIPELINE_STAGES.map(s => (
@@ -224,151 +258,191 @@ export function ListingDetail({ listing, priceHistory, notes }: ListingDetailPro
 
       {/* Description */}
       {listing.description && (
-        <div className="mt-6">
-          <h2 className="text-lg font-semibold text-gray-900 mb-2">Description</h2>
-          <p className="text-sm text-gray-700 whitespace-pre-line">{listing.description}</p>
-        </div>
+        <Section title="Description">
+          <p className="text-sm text-stone-700 leading-relaxed whitespace-pre-line">{listing.description}</p>
+        </Section>
       )}
 
-      {/* Location Map */}
+      {/* Map */}
       {listing.latitude != null && listing.longitude != null && (
-        <div className="mt-6">
-          <h2 className="text-lg font-semibold text-gray-900 mb-2">Location</h2>
-          <DetailMap
-            latitude={listing.latitude}
-            longitude={listing.longitude}
-            title={listing.title || listing.location || 'Property'}
-          />
-          <div className="flex items-center gap-3 mt-2">
+        <Section title="Location">
+          <div className="rounded-2xl overflow-hidden aurora-surface">
+            <DetailMap
+              latitude={listing.latitude}
+              longitude={listing.longitude}
+              title={listing.title || listing.location || 'Property'}
+            />
+          </div>
+          <div className="flex flex-wrap items-center gap-3 mt-3">
             {listing.address && (
-              <p className="text-sm text-gray-500">{listing.address}</p>
+              <p className="text-sm text-stone-600">{listing.address}</p>
             )}
             <a
               href={`https://www.google.com/maps?q=${listing.latitude},${listing.longitude}`}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-sm text-blue-600 hover:underline shrink-0"
+              className="text-sm text-stone-700 hover:text-stone-900 underline-offset-4 hover:underline ml-auto"
             >
-              Open in Google Maps
+              Open in Google Maps →
             </a>
           </div>
-        </div>
+        </Section>
       )}
 
       {/* Amenities */}
       {listing.amenities && listing.amenities.length > 0 && (
-        <div className="mt-6">
-          <h2 className="text-lg font-semibold text-gray-900 mb-2">Amenities</h2>
+        <Section title="Amenities">
           <div className="flex flex-wrap gap-2">
             {listing.amenities.map((a, i) => (
-              <span key={i} className="text-xs bg-gray-100 text-gray-700 px-2 py-1 rounded">
-                {a}
-              </span>
+              <span key={i} className="aurora-chip">{a}</span>
             ))}
           </div>
-        </div>
+        </Section>
       )}
 
-      {/* Seller Info */}
-      <div className="mt-6 bg-gray-50 rounded-lg p-4">
-        <h2 className="text-lg font-semibold text-gray-900 mb-2">Seller</h2>
-        <div className="text-sm text-gray-700 space-y-1">
-          {listing.agentName && (
-            <p className="font-medium">{listing.agentName}</p>
-          )}
-          {listing.sellerName && (
-            <p className={listing.agentName ? 'text-gray-500' : ''}>{listing.sellerName}</p>
-          )}
-          {listing.sellerType && <p className="text-gray-500">{listing.sellerType}</p>}
-          {listing.sellerVerified && <span className="text-green-600 text-xs">Verified</span>}
-        </div>
-        {listing.sellerWhatsapp && (
-          <a
-            href={`https://wa.me/${listing.sellerWhatsapp}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 mt-3 px-4 py-2 bg-green-500 text-white text-sm font-medium rounded-lg hover:bg-green-600 transition-colors"
+      {/* Seller */}
+      <Section title="Seller">
+        <div className="aurora-surface rounded-2xl p-5 flex flex-wrap items-start gap-4">
+          <span
+            className="w-12 h-12 rounded-full flex items-center justify-center font-serif text-xl text-stone-700 shrink-0"
+            style={{ background: 'linear-gradient(135deg, #ecf3ec, #ebe4cd)' }}
           >
-            <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
-              <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z" />
-            </svg>
-            WhatsApp
-          </a>
-        )}
-      </div>
-
-      {/* Dates */}
-      <div className="mt-4 text-xs text-gray-400 space-y-1">
-        <p>Published: {formatDate(listing.publishedAt)}</p>
-        <p>First seen: {formatDate(listing.firstSeenAt)}</p>
-        <p>Last seen: {formatRelativeDate(listing.lastSeenAt)}</p>
-        {listing.titleStatus && <p>Title status: {listing.titleStatus}</p>}
-        {listing.maintenanceCost && <p>Maintenance: {formatPrice(listing.maintenanceCost)}/mo</p>}
-        {listing.favoritesCount != null && <p>E24 favorites: {listing.favoritesCount}</p>}
-      </div>
+            {(listing.agentName || listing.sellerName || '?').charAt(0).toUpperCase()}
+          </span>
+          <div className="flex-1 min-w-0">
+            {listing.agentName && (
+              <p className="font-serif text-lg text-stone-900">{listing.agentName}</p>
+            )}
+            {listing.sellerName && (
+              <p className={`text-sm ${listing.agentName ? 'text-stone-500' : 'font-serif text-lg text-stone-900'}`}>
+                {listing.sellerName}
+              </p>
+            )}
+            <div className="flex flex-wrap gap-1.5 mt-2">
+              {listing.sellerType && <span className="aurora-chip capitalize">{listing.sellerType}</span>}
+              {listing.sellerVerified && (
+                <span className="aurora-chip aurora-chip-slate">
+                  <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 20 20">
+                    <path fillRule="evenodd" d="M6.267 3.455a3.066 3.066 0 001.745-.723 3.066 3.066 0 013.976 0 3.066 3.066 0 001.745.723 3.066 3.066 0 012.812 2.812c.051.643.304 1.254.723 1.745a3.066 3.066 0 010 3.976 3.066 3.066 0 00-.723 1.745 3.066 3.066 0 01-2.812 2.812 3.066 3.066 0 00-1.745.723 3.066 3.066 0 01-3.976 0 3.066 3.066 0 00-1.745-.723 3.066 3.066 0 01-2.812-2.812 3.066 3.066 0 00-.723-1.745 3.066 3.066 0 010-3.976 3.066 3.066 0 00.723-1.745 3.066 3.066 0 012.812-2.812zm7.44 5.252a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+                  </svg>
+                  Verified
+                </span>
+              )}
+            </div>
+          </div>
+          {listing.sellerWhatsapp && (
+            <a
+              href={`https://wa.me/${listing.sellerWhatsapp}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-emerald-500 text-white text-sm font-medium hover:bg-emerald-600 hover:-translate-y-0.5 transition-all shadow-md shadow-emerald-200"
+            >
+              <svg className="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z" />
+              </svg>
+              WhatsApp
+            </a>
+          )}
+        </div>
+      </Section>
 
       {/* Price History */}
       {priceHistory.length > 0 && (
-        <div className="mt-6">
-          <h2 className="text-lg font-semibold text-gray-900 mb-2">Price History</h2>
-          <PriceHistoryChart data={priceHistory} currentPrice={listing.price} />
-          <div className="space-y-2 mt-3">
-            {priceHistory.map(ph => (
-              <div key={ph.id} className="flex justify-between items-center text-sm py-1 border-b last:border-0">
-                <span className="text-gray-700">{formatPrice(ph.price)}</span>
-                <span className="text-gray-400 text-xs">{formatDate(ph.recordedAt)}</span>
-              </div>
-            ))}
+        <Section title="Price History">
+          <div className="aurora-surface rounded-2xl p-5">
+            <PriceHistoryChart data={priceHistory} currentPrice={listing.price} />
+            <div className="mt-3 divide-y divide-stone-200/60">
+              {priceHistory.map(ph => (
+                <div key={ph.id} className="flex justify-between items-center text-sm py-2">
+                  <span className="font-serif text-stone-900">{formatPrice(ph.price)}</span>
+                  <span className="text-stone-400 text-xs">{formatDate(ph.recordedAt)}</span>
+                </div>
+              ))}
+            </div>
           </div>
-        </div>
+        </Section>
       )}
 
       {/* Notes */}
-      <div className="mt-6">
-        <h2 className="text-lg font-semibold text-gray-900 mb-2">Notes</h2>
+      <Section title="Notes">
         <div className="flex gap-2 mb-3">
           <input
             type="text"
-            placeholder="Add a note..."
+            placeholder="Add a private note…"
             value={noteText}
             onChange={e => setNoteText(e.target.value)}
             onKeyDown={e => e.key === 'Enter' && addNote()}
-            className="flex-1 px-3 py-1.5 text-sm border rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="aurora-input flex-1"
           />
           <button
             onClick={addNote}
             disabled={!noteText.trim()}
-            className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+            className="aurora-pill aurora-pill-primary disabled:opacity-40 disabled:cursor-not-allowed"
           >
             Add
           </button>
         </div>
         {localNotes.length === 0 ? (
-          <p className="text-sm text-gray-500">No notes yet.</p>
+          <p className="text-sm text-stone-500 italic">No notes yet.</p>
         ) : (
           <div className="space-y-2">
             {localNotes.map(note => (
-              <div key={note.id} className="bg-gray-50 rounded p-3">
-                <p className="text-sm text-gray-700">{note.content}</p>
-                <p className="text-xs text-gray-400 mt-1">
-                  {note.type !== 'note' && <span className="capitalize mr-2">{note.type.replace('_', ' ')}</span>}
-                  {formatRelativeDate(note.createdAt)}
+              <div key={note.id} className="aurora-surface-soft rounded-2xl p-4">
+                <p className="text-sm text-stone-800 leading-relaxed">{note.content}</p>
+                <p className="text-xs text-stone-500 mt-2 flex items-center gap-2">
+                  {note.type !== 'note' && (
+                    <span className="aurora-chip capitalize">{note.type.replace('_', ' ')}</span>
+                  )}
+                  <span>{formatRelativeDate(note.createdAt)}</span>
                 </p>
               </div>
             ))}
           </div>
         )}
+      </Section>
+
+      {/* Meta */}
+      <div className="mt-8 aurora-surface-soft rounded-2xl p-5">
+        <p className="text-[11px] uppercase tracking-wider text-stone-500 font-medium mb-2">Meta</p>
+        <dl className="grid grid-cols-2 sm:grid-cols-3 gap-x-6 gap-y-1.5 text-xs text-stone-600">
+          <MetaRow label="Published" value={formatDate(listing.publishedAt)} />
+          <MetaRow label="First seen" value={formatDate(listing.firstSeenAt)} />
+          <MetaRow label="Last seen" value={formatRelativeDate(listing.lastSeenAt)} />
+          {listing.titleStatus && <MetaRow label="Title" value={listing.titleStatus} />}
+          {listing.maintenanceCost != null && <MetaRow label="Maintenance" value={`${formatPrice(listing.maintenanceCost)}/mo`} />}
+          {listing.favoritesCount != null && <MetaRow label="E24 favorites" value={String(listing.favoritesCount)} />}
+        </dl>
       </div>
     </div>
   );
 }
 
-function Spec({ label, value }: { label: string; value: string | number | null | undefined }) {
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="mt-8">
+      <h2 className="font-serif text-xl text-stone-900 mb-3">
+        <span className="aurora-rule">{title}</span>
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+function Spec({ label, value }: { label: string; value: string | number | null | undefined; icon?: string }) {
   if (value == null) return null;
   return (
-    <div className="bg-gray-50 rounded p-2">
-      <p className="text-xs text-gray-500">{label}</p>
-      <p className="text-sm font-medium text-gray-900">{value}</p>
+    <div className="aurora-surface rounded-2xl px-4 py-3">
+      <p className="text-[10px] uppercase tracking-wider text-stone-500 font-medium">{label}</p>
+      <p className="font-serif text-xl text-stone-900 mt-0.5 tabular-nums">{value}</p>
+    </div>
+  );
+}
+
+function MetaRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-baseline gap-2">
+      <dt className="text-stone-500 shrink-0">{label}</dt>
+      <dd className="text-stone-800 truncate">{value}</dd>
     </div>
   );
 }

--- a/web/src/components/listings/ListingDetail.tsx
+++ b/web/src/components/listings/ListingDetail.tsx
@@ -259,7 +259,9 @@ export function ListingDetail({ listing, priceHistory, notes }: ListingDetailPro
       {/* Description */}
       {listing.description && (
         <Section title="Description">
-          <p className="text-sm text-stone-700 leading-relaxed whitespace-pre-line">{listing.description}</p>
+          <div className="aurora-surface rounded-2xl px-6 py-5">
+            <DescriptionBody text={listing.description} />
+          </div>
         </Section>
       )}
 
@@ -434,6 +436,40 @@ function Spec({ label, value }: { label: string; value: string | number | null |
     <div className="aurora-surface rounded-2xl px-4 py-3">
       <p className="text-[10px] uppercase tracking-wider text-stone-500 font-medium">{label}</p>
       <p className="font-serif text-xl text-stone-900 mt-0.5 tabular-nums">{value}</p>
+    </div>
+  );
+}
+
+function DescriptionBody({ text }: { text: string }) {
+  const blocks = text
+    .replace(/\r\n/g, '\n')
+    .split(/\n{2,}/)
+    .map(b => b.trim())
+    .filter(Boolean);
+
+  return (
+    <div className="space-y-3 text-[15px] text-stone-700 leading-relaxed">
+      {blocks.map((block, i) => {
+        const lines = block.split('\n').map(l => l.trim()).filter(Boolean);
+        const looksLikeList = lines.length > 1 && lines.every(l => l.length < 80);
+        if (looksLikeList) {
+          return (
+            <ul key={i} className="space-y-1">
+              {lines.map((line, j) => (
+                <li key={j} className="flex gap-2.5">
+                  <span aria-hidden className="mt-2 w-1 h-1 rounded-full bg-stone-400 shrink-0" />
+                  <span>{line}</span>
+                </li>
+              ))}
+            </ul>
+          );
+        }
+        return (
+          <p key={i} className="whitespace-pre-line">
+            {block}
+          </p>
+        );
+      })}
     </div>
   );
 }

--- a/web/src/components/listings/ListingFilters.tsx
+++ b/web/src/components/listings/ListingFilters.tsx
@@ -66,19 +66,14 @@ export function ListingFilters({ searchParams, onUpdate }: ListingFiltersProps) 
     <div className="aurora-surface rounded-2xl p-4 mb-4">
       <div className="flex flex-wrap gap-2.5 items-end">
         <div className="flex-1 min-w-[220px] flex gap-1.5">
-          <div className="relative flex-1">
-            <svg className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-stone-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.8}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5-5m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-            </svg>
-            <input
-              type="text"
-              placeholder="Search by title or description…"
-              value={q}
-              onChange={e => setQ(e.target.value)}
-              onKeyDown={e => { if (e.key === 'Enter') submitSearch(); }}
-              className="aurora-input w-full pl-9"
-            />
-          </div>
+          <input
+            type="text"
+            placeholder="Search by title or description…"
+            value={q}
+            onChange={e => setQ(e.target.value)}
+            onKeyDown={e => { if (e.key === 'Enter') submitSearch(); }}
+            className="aurora-input flex-1"
+          />
           <button
             onClick={submitSearch}
             className="aurora-pill aurora-pill-primary"

--- a/web/src/components/listings/ListingFilters.tsx
+++ b/web/src/components/listings/ListingFilters.tsx
@@ -63,20 +63,25 @@ export function ListingFilters({ searchParams, onUpdate }: ListingFiltersProps) 
   );
 
   return (
-    <div className="bg-white rounded-lg border border-gray-200 p-4 mb-4">
-      <div className="flex flex-wrap gap-3 items-end">
-        <div className="flex-1 min-w-[200px] flex gap-1">
-          <input
-            type="text"
-            placeholder="Search by title, description..."
-            value={q}
-            onChange={e => setQ(e.target.value)}
-            onKeyDown={e => { if (e.key === 'Enter') submitSearch(); }}
-            className="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
-          />
+    <div className="aurora-surface rounded-2xl p-4 mb-4">
+      <div className="flex flex-wrap gap-2.5 items-end">
+        <div className="flex-1 min-w-[220px] flex gap-1.5">
+          <div className="relative flex-1">
+            <svg className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-stone-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.8}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5-5m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+            </svg>
+            <input
+              type="text"
+              placeholder="Search by title or description…"
+              value={q}
+              onChange={e => setQ(e.target.value)}
+              onKeyDown={e => { if (e.key === 'Enter') submitSearch(); }}
+              className="aurora-input w-full pl-9"
+            />
+          </div>
           <button
             onClick={submitSearch}
-            className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700"
+            className="aurora-pill aurora-pill-primary"
           >
             Search
           </button>
@@ -101,14 +106,17 @@ export function ListingFilters({ searchParams, onUpdate }: ListingFiltersProps) 
         />
         <button
           onClick={() => setExpanded(!expanded)}
-          className="px-3 py-1.5 text-sm text-gray-700 border border-gray-300 rounded hover:bg-gray-50"
+          className="aurora-pill aurora-pill-ghost"
         >
-          {expanded ? 'Less Filters' : 'More Filters'}
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.8}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M3 5h18M6 12h12M10 19h4" />
+          </svg>
+          {expanded ? 'Less filters' : 'More filters'}
         </button>
       </div>
 
       {expanded && (
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mt-3 pt-3 border-t border-gray-200">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mt-4 pt-4 border-t border-stone-200/60">
           <RangeFilter
             label="Price"
             minValue={searchParams.get('priceMin') || ''}
@@ -137,11 +145,11 @@ export function ListingFilters({ searchParams, onUpdate }: ListingFiltersProps) 
             min="0"
           />
           <div>
-            <label className="block text-xs text-gray-500 mb-1">City</label>
+            <label className="block text-[11px] uppercase tracking-wider text-stone-500 mb-1.5 font-medium">City</label>
             <select
               value={searchParams.get('city') || ''}
               onChange={e => onUpdate({ city: e.target.value || undefined })}
-              className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded bg-white text-gray-900"
+              className="aurora-input w-full"
             >
               <option value="">All Cities</option>
               {cityOptions.map(opt => (
@@ -157,11 +165,11 @@ export function ListingFilters({ searchParams, onUpdate }: ListingFiltersProps) 
             onMaxChange={v => onUpdate({ landAreaMax: v || undefined })}
           />
           <div>
-            <label className="block text-xs text-gray-500 mb-1">Status</label>
+            <label className="block text-[11px] uppercase tracking-wider text-stone-500 mb-1.5 font-medium">Status</label>
             <select
               value={searchParams.get('status') || 'active'}
               onChange={e => onUpdate({ status: e.target.value === 'active' ? undefined : e.target.value })}
-              className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded bg-white text-gray-900"
+              className="aurora-input w-full"
             >
               <option value="active">Active only</option>
               <option value="removed">Removed only</option>
@@ -228,46 +236,46 @@ const SearchableSelect = memo(function SearchableSelect({
     <div ref={ref} className="relative">
       <button
         onClick={() => { setOpen(!open); setSearch(''); }}
-        className="px-3 py-1.5 text-sm border border-gray-300 rounded bg-white text-gray-900 min-w-[160px] text-left flex items-center justify-between gap-2 hover:bg-gray-50"
+        className="aurora-input min-w-[170px] text-left flex items-center justify-between gap-2 hover:bg-white/85"
       >
-        <span className={value ? 'text-gray-900' : 'text-gray-500'}>
+        <span className={value ? 'text-stone-900' : 'text-stone-500'}>
           {value || placeholder}
         </span>
         {value ? (
           <span
             onClick={e => { e.stopPropagation(); onChange(''); setOpen(false); }}
-            className="text-gray-400 hover:text-gray-600"
+            className="text-stone-400 hover:text-stone-700 text-base leading-none"
           >
             &times;
           </span>
         ) : (
-          <svg className="w-3 h-3 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="w-3 h-3 text-stone-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
           </svg>
         )}
       </button>
       {open && (
-        <div className="absolute z-[1000] mt-1 w-64 bg-white border border-gray-200 rounded-lg shadow-lg max-h-64 overflow-hidden">
-          <div className="p-2 border-b border-gray-100">
+        <div className="absolute z-[1000] mt-1.5 w-64 rounded-2xl shadow-xl max-h-64 overflow-hidden aurora-surface-strong">
+          <div className="p-2 border-b border-stone-200/60">
             <input
               type="text"
-              placeholder="Type to filter..."
+              placeholder="Type to filter…"
               value={search}
               onChange={e => setSearch(e.target.value)}
-              className="w-full px-2 py-1 text-sm border border-gray-300 rounded text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              className="aurora-input w-full text-sm"
               autoFocus
             />
           </div>
           <div className="overflow-y-auto max-h-48">
             {filtered.length === 0 ? (
-              <p className="px-3 py-2 text-sm text-gray-500">No matches</p>
+              <p className="px-3 py-2 text-sm text-stone-500">No matches</p>
             ) : (
               filtered.slice(0, 50).map(opt => (
                 <button
                   key={opt.value}
                   onClick={() => { onChange(opt.value); setOpen(false); }}
-                  className={`w-full text-left px-3 py-1.5 text-sm hover:bg-blue-50 ${
-                    opt.value === value ? 'bg-blue-50 text-blue-700 font-medium' : 'text-gray-700'
+                  className={`w-full text-left px-3 py-1.5 text-sm transition-colors hover:bg-emerald-50/70 ${
+                    opt.value === value ? 'bg-emerald-50 text-emerald-800 font-medium' : 'text-stone-700'
                   }`}
                 >
                   {opt.label}
@@ -297,7 +305,7 @@ function SelectFilter({
       <select
         value={value}
         onChange={e => onChange(e.target.value)}
-        className="px-3 py-1.5 text-sm border border-gray-300 rounded bg-white text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        className="aurora-input min-w-[140px]"
       >
         <option value="">All {label}</option>
         {options.map(opt => (
@@ -341,21 +349,21 @@ function RangeFilter({
 
   return (
     <div>
-      <label className="block text-xs text-gray-500 mb-1">{label}</label>
+      <label className="block text-[11px] uppercase tracking-wider text-stone-500 mb-1.5 font-medium">{label}</label>
       <div className="flex gap-1">
         <input
           type="number"
           placeholder="Min"
           value={localMin}
           onChange={e => setLocalMin(e.target.value)}
-          className="w-1/2 px-2 py-1.5 text-sm border border-gray-300 rounded text-gray-900 placeholder:text-gray-400"
+          className="aurora-input w-1/2 placeholder:text-stone-400"
         />
         <input
           type="number"
           placeholder="Max"
           value={localMax}
           onChange={e => setLocalMax(e.target.value)}
-          className="w-1/2 px-2 py-1.5 text-sm border border-gray-300 rounded text-gray-900 placeholder:text-gray-400"
+          className="aurora-input w-1/2 placeholder:text-stone-400"
         />
       </div>
     </div>
@@ -385,12 +393,12 @@ function DebouncedNumberInput({
 
   return (
     <div>
-      <label className="block text-xs text-gray-500 mb-1">{label}</label>
+      <label className="block text-[11px] uppercase tracking-wider text-stone-500 mb-1.5 font-medium">{label}</label>
       <input
         type="number"
         value={local}
         onChange={e => setLocal(e.target.value)}
-        className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded text-gray-900"
+        className="aurora-input w-full"
         min={min}
       />
     </div>

--- a/web/src/components/listings/ListingFilters.tsx
+++ b/web/src/components/listings/ListingFilters.tsx
@@ -16,9 +16,35 @@ interface CategoriesData {
   locations: Array<{ location: string; count: number }>;
 }
 
+type FilterValues = Record<string, string>;
+
+const FILTER_KEYS = [
+  'q', 'location', 'category', 'subcategory', 'city', 'province',
+  'priceMin', 'priceMax',
+  'bedroomsMin', 'bedroomsMax', 'bathroomsMin',
+  'areaMin', 'areaMax', 'landAreaMin', 'landAreaMax',
+  'status', 'isFavorite', 'inPipeline',
+] as const;
+
+function paramsToObject(searchParams: URLSearchParams): FilterValues {
+  const obj: FilterValues = {};
+  for (const key of FILTER_KEYS) {
+    const v = searchParams.get(key);
+    if (v) obj[key] = v;
+  }
+  return obj;
+}
+
 export function ListingFilters({ searchParams, onUpdate }: ListingFiltersProps) {
-  const [q, setQ] = useState(searchParams.get('q') || '');
+  const paramsKey = searchParams.toString();
+  const [staged, setStaged] = useState<FilterValues>(() => paramsToObject(searchParams));
   const [expanded, setExpanded] = useState(false);
+
+  // Sync local staging state when the URL changes externally (chip removal,
+  // saved-search application, etc.). The string key avoids object identity churn.
+  useEffect(() => {
+    setStaged(paramsToObject(new URLSearchParams(paramsKey)));
+  }, [paramsKey]);
 
   const { data: catData } = useQuery<CategoriesData>({
     queryKey: ['categories'],
@@ -30,20 +56,40 @@ export function ListingFilters({ searchParams, onUpdate }: ListingFiltersProps) 
     staleTime: 5 * 60 * 1000,
   });
 
-  useEffect(() => {
-    setQ(searchParams.get('q') || '');
-  }, [searchParams]);
+  const setField = useCallback((key: string, value: string | undefined) => {
+    setStaged(prev => {
+      const next = { ...prev };
+      if (value == null || value === '') delete next[key];
+      else next[key] = value;
+      return next;
+    });
+  }, []);
 
-  const submitSearch = () => {
-    const current = searchParams.get('q') || '';
-    if (q !== current) {
-      onUpdate({ q: q || undefined });
+  const applied = useMemo(() => paramsToObject(new URLSearchParams(paramsKey)), [paramsKey]);
+  const pendingCount = useMemo(() => {
+    const allKeys = new Set([...Object.keys(staged), ...Object.keys(applied)]);
+    let count = 0;
+    for (const k of allKeys) if (staged[k] !== applied[k]) count++;
+    return count;
+  }, [staged, applied]);
+
+  const applyFilters = useCallback(() => {
+    if (pendingCount === 0) return;
+    const updates: Record<string, string | undefined> = {};
+    const allKeys = new Set([...Object.keys(staged), ...Object.keys(applied)]);
+    for (const k of allKeys) {
+      if (staged[k] !== applied[k]) updates[k] = staged[k] || undefined;
     }
-  };
+    onUpdate(updates);
+  }, [staged, applied, pendingCount, onUpdate]);
+
+  const resetStaged = useCallback(() => {
+    setStaged(applied);
+  }, [applied]);
 
   const onLocationChange = useCallback(
-    (v: string) => onUpdate({ location: v || undefined }),
-    [onUpdate]
+    (v: string) => setField('location', v || undefined),
+    [setField]
   );
 
   const locationOptions = useMemo(
@@ -65,39 +111,31 @@ export function ListingFilters({ searchParams, onUpdate }: ListingFiltersProps) 
   return (
     <div className="aurora-surface rounded-2xl p-4 mb-4">
       <div className="flex flex-wrap gap-2.5 items-end">
-        <div className="flex-1 min-w-[220px] flex gap-1.5">
-          <input
-            type="text"
-            placeholder="Search by title or description…"
-            value={q}
-            onChange={e => setQ(e.target.value)}
-            onKeyDown={e => { if (e.key === 'Enter') submitSearch(); }}
-            className="aurora-input flex-1"
-          />
-          <button
-            onClick={submitSearch}
-            className="aurora-pill aurora-pill-primary"
-          >
-            Search
-          </button>
-        </div>
+        <input
+          type="text"
+          placeholder="Search by title or description…"
+          value={staged.q || ''}
+          onChange={e => setField('q', e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter') applyFilters(); }}
+          className="aurora-input flex-1 min-w-[220px]"
+        />
         <SearchableSelect
           placeholder="All Locations"
-          value={searchParams.get('location') || ''}
+          value={staged.location || ''}
           options={locationOptions}
           onChange={onLocationChange}
         />
         <SelectFilter
           label="Categories"
-          value={searchParams.get('category') || ''}
+          value={staged.category || ''}
           options={CATEGORY_OPTIONS as unknown as Array<{ value: string; label: string }>}
-          onChange={v => onUpdate({ category: v || undefined })}
+          onChange={v => setField('category', v || undefined)}
         />
         <SelectFilter
           label="Types"
-          value={searchParams.get('subcategory') || ''}
+          value={staged.subcategory || ''}
           options={SUBCATEGORY_OPTIONS as unknown as Array<{ value: string; label: string }>}
-          onChange={v => onUpdate({ subcategory: v || undefined })}
+          onChange={v => setField('subcategory', v || undefined)}
         />
         <button
           onClick={() => setExpanded(!expanded)}
@@ -108,42 +146,65 @@ export function ListingFilters({ searchParams, onUpdate }: ListingFiltersProps) 
           </svg>
           {expanded ? 'Less filters' : 'More filters'}
         </button>
+        <div className="flex items-center gap-1.5 ml-auto">
+          {pendingCount > 0 && (
+            <button
+              onClick={resetStaged}
+              className="aurora-pill aurora-pill-ghost"
+              type="button"
+            >
+              Reset
+            </button>
+          )}
+          <button
+            onClick={applyFilters}
+            disabled={pendingCount === 0}
+            className={pendingCount > 0 ? 'aurora-pill aurora-pill-primary' : 'aurora-pill aurora-pill-ghost'}
+            type="button"
+          >
+            Apply{pendingCount > 0 ? ` (${pendingCount})` : ''}
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+            </svg>
+          </button>
+        </div>
       </div>
 
       {expanded && (
         <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mt-4 pt-4 border-t border-stone-200/60">
           <RangeFilter
             label="Price"
-            minValue={searchParams.get('priceMin') || ''}
-            maxValue={searchParams.get('priceMax') || ''}
-            onMinChange={v => onUpdate({ priceMin: v || undefined })}
-            onMaxChange={v => onUpdate({ priceMax: v || undefined })}
+            minValue={staged.priceMin || ''}
+            maxValue={staged.priceMax || ''}
+            onMinChange={v => setField('priceMin', v || undefined)}
+            onMaxChange={v => setField('priceMax', v || undefined)}
           />
           <RangeFilter
             label="Bedrooms"
-            minValue={searchParams.get('bedroomsMin') || ''}
-            maxValue={searchParams.get('bedroomsMax') || ''}
-            onMinChange={v => onUpdate({ bedroomsMin: v || undefined })}
-            onMaxChange={v => onUpdate({ bedroomsMax: v || undefined })}
+            minValue={staged.bedroomsMin || ''}
+            maxValue={staged.bedroomsMax || ''}
+            onMinChange={v => setField('bedroomsMin', v || undefined)}
+            onMaxChange={v => setField('bedroomsMax', v || undefined)}
           />
           <RangeFilter
             label="Area (m²)"
-            minValue={searchParams.get('areaMin') || ''}
-            maxValue={searchParams.get('areaMax') || ''}
-            onMinChange={v => onUpdate({ areaMin: v || undefined })}
-            onMaxChange={v => onUpdate({ areaMax: v || undefined })}
+            minValue={staged.areaMin || ''}
+            maxValue={staged.areaMax || ''}
+            onMinChange={v => setField('areaMin', v || undefined)}
+            onMaxChange={v => setField('areaMax', v || undefined)}
           />
-          <DebouncedNumberInput
-            label="Bathrooms Min"
-            value={searchParams.get('bathroomsMin') || ''}
-            onChange={v => onUpdate({ bathroomsMin: v || undefined })}
+          <NumberField
+            label="Bathrooms min"
+            value={staged.bathroomsMin || ''}
+            onChange={v => setField('bathroomsMin', v || undefined)}
             min="0"
+            onSubmit={applyFilters}
           />
           <div>
             <label className="block text-[11px] uppercase tracking-wider text-stone-500 mb-1.5 font-medium">City</label>
             <select
-              value={searchParams.get('city') || ''}
-              onChange={e => onUpdate({ city: e.target.value || undefined })}
+              value={staged.city || ''}
+              onChange={e => setField('city', e.target.value || undefined)}
               className="aurora-input w-full"
             >
               <option value="">All Cities</option>
@@ -154,16 +215,16 @@ export function ListingFilters({ searchParams, onUpdate }: ListingFiltersProps) 
           </div>
           <RangeFilter
             label="Land Area (m²)"
-            minValue={searchParams.get('landAreaMin') || ''}
-            maxValue={searchParams.get('landAreaMax') || ''}
-            onMinChange={v => onUpdate({ landAreaMin: v || undefined })}
-            onMaxChange={v => onUpdate({ landAreaMax: v || undefined })}
+            minValue={staged.landAreaMin || ''}
+            maxValue={staged.landAreaMax || ''}
+            onMinChange={v => setField('landAreaMin', v || undefined)}
+            onMaxChange={v => setField('landAreaMax', v || undefined)}
           />
           <div>
             <label className="block text-[11px] uppercase tracking-wider text-stone-500 mb-1.5 font-medium">Status</label>
             <select
-              value={searchParams.get('status') || 'active'}
-              onChange={e => onUpdate({ status: e.target.value === 'active' ? undefined : e.target.value })}
+              value={staged.status || 'active'}
+              onChange={e => setField('status', e.target.value === 'active' ? undefined : e.target.value)}
               className="aurora-input w-full"
             >
               <option value="active">Active only</option>
@@ -172,20 +233,20 @@ export function ListingFilters({ searchParams, onUpdate }: ListingFiltersProps) 
             </select>
           </div>
           <div className="flex items-end gap-4">
-            <label className="flex items-center gap-1.5 text-sm text-gray-700">
+            <label className="flex items-center gap-1.5 text-sm text-stone-700">
               <input
                 type="checkbox"
-                checked={searchParams.get('isFavorite') === 'true'}
-                onChange={e => onUpdate({ isFavorite: e.target.checked ? 'true' : undefined })}
+                checked={staged.isFavorite === 'true'}
+                onChange={e => setField('isFavorite', e.target.checked ? 'true' : undefined)}
                 className="rounded"
               />
               Favorites only
             </label>
-            <label className="flex items-center gap-1.5 text-sm text-gray-700">
+            <label className="flex items-center gap-1.5 text-sm text-stone-700">
               <input
                 type="checkbox"
-                checked={searchParams.get('inPipeline') === 'true'}
-                onChange={e => onUpdate({ inPipeline: e.target.checked ? 'true' : undefined })}
+                checked={staged.inPipeline === 'true'}
+                onChange={e => setField('inPipeline', e.target.checked ? 'true' : undefined)}
                 className="rounded"
               />
               In Pipeline
@@ -324,24 +385,6 @@ function RangeFilter({
   onMinChange: (value: string) => void;
   onMaxChange: (value: string) => void;
 }) {
-  const [localMin, setLocalMin] = useState(minValue);
-  const [localMax, setLocalMax] = useState(maxValue);
-
-  useEffect(() => { setLocalMin(minValue); }, [minValue]);
-  useEffect(() => { setLocalMax(maxValue); }, [maxValue]);
-
-  useEffect(() => {
-    if (localMin === minValue) return;
-    const timer = setTimeout(() => onMinChange(localMin), 400);
-    return () => clearTimeout(timer);
-  }, [localMin]);
-
-  useEffect(() => {
-    if (localMax === maxValue) return;
-    const timer = setTimeout(() => onMaxChange(localMax), 400);
-    return () => clearTimeout(timer);
-  }, [localMax]);
-
   return (
     <div>
       <label className="block text-[11px] uppercase tracking-wider text-stone-500 mb-1.5 font-medium">{label}</label>
@@ -349,15 +392,15 @@ function RangeFilter({
         <input
           type="number"
           placeholder="Min"
-          value={localMin}
-          onChange={e => setLocalMin(e.target.value)}
+          value={minValue}
+          onChange={e => onMinChange(e.target.value)}
           className="aurora-input w-1/2 placeholder:text-stone-400"
         />
         <input
           type="number"
           placeholder="Max"
-          value={localMax}
-          onChange={e => setLocalMax(e.target.value)}
+          value={maxValue}
+          onChange={e => onMaxChange(e.target.value)}
           className="aurora-input w-1/2 placeholder:text-stone-400"
         />
       </div>
@@ -365,34 +408,27 @@ function RangeFilter({
   );
 }
 
-function DebouncedNumberInput({
+function NumberField({
   label,
   value,
   onChange,
   min,
+  onSubmit,
 }: {
   label: string;
   value: string;
   onChange: (value: string) => void;
   min?: string;
+  onSubmit?: () => void;
 }) {
-  const [local, setLocal] = useState(value);
-
-  useEffect(() => { setLocal(value); }, [value]);
-
-  useEffect(() => {
-    if (local === value) return;
-    const timer = setTimeout(() => onChange(local), 400);
-    return () => clearTimeout(timer);
-  }, [local]);
-
   return (
     <div>
       <label className="block text-[11px] uppercase tracking-wider text-stone-500 mb-1.5 font-medium">{label}</label>
       <input
         type="number"
-        value={local}
-        onChange={e => setLocal(e.target.value)}
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        onKeyDown={e => { if (e.key === 'Enter' && onSubmit) onSubmit(); }}
         className="aurora-input w-full"
         min={min}
       />

--- a/web/src/components/listings/ListingGrid.tsx
+++ b/web/src/components/listings/ListingGrid.tsx
@@ -36,14 +36,19 @@ interface ListingGridProps {
 export function ListingGrid({ listings, isLoading }: ListingGridProps) {
   if (isLoading) {
     return (
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
         {[...Array(8)].map((_, i) => (
-          <div key={i} className="bg-white rounded-lg border overflow-hidden animate-pulse">
-            <div className="aspect-[4/3] bg-gray-200" />
-            <div className="p-3 space-y-2">
-              <div className="h-5 bg-gray-200 rounded w-1/2" />
-              <div className="h-4 bg-gray-200 rounded w-3/4" />
-              <div className="h-3 bg-gray-200 rounded w-1/3" />
+          <div key={i} className="rounded-3xl aurora-surface overflow-hidden animate-pulse">
+            <div className="aspect-[5/4] bg-stone-200/60" />
+            <div className="px-5 py-4 space-y-2.5">
+              <div className="h-7 bg-stone-200/60 rounded-md w-1/2" />
+              <div className="h-4 bg-stone-200/60 rounded-md w-3/4" />
+              <div className="h-3 bg-stone-200/60 rounded-md w-1/3" />
+              <div className="flex gap-2 pt-2">
+                <div className="h-3 w-10 bg-stone-200/60 rounded-md" />
+                <div className="h-3 w-10 bg-stone-200/60 rounded-md" />
+                <div className="h-3 w-12 bg-stone-200/60 rounded-md" />
+              </div>
             </div>
           </div>
         ))}
@@ -53,14 +58,21 @@ export function ListingGrid({ listings, isLoading }: ListingGridProps) {
 
   if (listings.length === 0) {
     return (
-      <div className="text-center py-12">
-        <p className="text-gray-500">No listings found matching your criteria.</p>
+      <div className="text-center py-20 rounded-3xl aurora-surface">
+        <div className="inline-flex items-center justify-center w-16 h-16 rounded-full mb-4"
+             style={{ background: 'linear-gradient(135deg, #ecf3ec, #ebe4cd)' }}>
+          <svg className="w-7 h-7 text-stone-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={1.5}>
+            <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5-5m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+          </svg>
+        </div>
+        <p className="font-serif text-2xl text-stone-900">Nothing here yet</p>
+        <p className="text-sm text-stone-500 mt-1">Try loosening your filters or saving the search to be notified.</p>
       </div>
     );
   }
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
       {listings.map(listing => (
         <ListingCard key={listing.adId} listing={listing} />
       ))}

--- a/web/src/components/listings/ListingSortBar.tsx
+++ b/web/src/components/listings/ListingSortBar.tsx
@@ -13,19 +13,34 @@ export function ListingSortBar({ searchParams, onUpdate, total, isLoading }: Lis
   const sort = searchParams.get('sort') || 'published_desc';
 
   return (
-    <div className="flex items-center justify-between mb-4">
-      <p className="text-sm text-gray-600">
-        {isLoading ? 'Loading...' : `${total?.toLocaleString() ?? 0} listings found`}
+    <div className="flex items-center justify-between mb-5">
+      <p className="text-sm text-stone-600">
+        {isLoading ? (
+          <span className="inline-flex items-center gap-2">
+            <span className="w-1.5 h-1.5 rounded-full bg-stone-400 animate-pulse" />
+            Loading…
+          </span>
+        ) : (
+          <>
+            <span className="font-serif text-stone-900 text-lg tabular-nums mr-1">
+              {total?.toLocaleString() ?? 0}
+            </span>
+            properties
+          </>
+        )}
       </p>
-      <select
-        value={sort}
-        onChange={e => onUpdate({ sort: e.target.value })}
-        className="px-3 py-1.5 text-sm border border-gray-300 rounded bg-white text-gray-900"
-      >
-        {SORT_OPTIONS.map(opt => (
-          <option key={opt.value} value={opt.value}>{opt.label}</option>
-        ))}
-      </select>
+      <div className="flex items-center gap-2">
+        <span className="text-[11px] uppercase tracking-wider text-stone-500 font-medium">Sort</span>
+        <select
+          value={sort}
+          onChange={e => onUpdate({ sort: e.target.value })}
+          className="aurora-input min-w-[160px]"
+        >
+          {SORT_OPTIONS.map(opt => (
+            <option key={opt.value} value={opt.value}>{opt.label}</option>
+          ))}
+        </select>
+      </div>
     </div>
   );
 }

--- a/web/src/components/listings/PriceHistoryChart.tsx
+++ b/web/src/components/listings/PriceHistoryChart.tsx
@@ -29,21 +29,25 @@ export function PriceHistoryChart({ data, currentPrice }: PriceHistoryChartProps
   return (
     <div className="h-48">
       <ResponsiveContainer width="100%" height="100%">
-        <LineChart data={chartData}>
-          <XAxis dataKey="date" tick={{ fontSize: 11 }} />
+        <LineChart data={chartData} margin={{ top: 8, right: 8, left: -8, bottom: 0 }}>
+          <XAxis dataKey="date" tick={{ fontSize: 11, fill: '#78716c' }} axisLine={false} tickLine={false} />
           <YAxis
-            tick={{ fontSize: 11 }}
+            tick={{ fontSize: 11, fill: '#78716c' }}
             tickFormatter={v => `$${(v / 1000).toFixed(0)}k`}
+            axisLine={false}
+            tickLine={false}
           />
           <Tooltip
+            contentStyle={{ background: 'rgba(255,255,255,0.97)', border: '1px solid #e7e5e4', borderRadius: 12, fontSize: 12 }}
             formatter={(value) => [formatPrice(value as number), 'Price']}
           />
           <Line
             type="monotone"
             dataKey="price"
-            stroke="#3b82f6"
-            strokeWidth={2}
-            dot={{ r: 4 }}
+            stroke="#4a6b4a"
+            strokeWidth={2.5}
+            dot={{ r: 4, fill: '#4a6b4a', strokeWidth: 0 }}
+            activeDot={{ r: 6, fill: '#1a1a1a', strokeWidth: 0 }}
           />
         </LineChart>
       </ResponsiveContainer>

--- a/web/src/components/saved-searches/SaveSearchModal.tsx
+++ b/web/src/components/saved-searches/SaveSearchModal.tsx
@@ -26,33 +26,63 @@ export function SaveSearchModal({ filters, onClose }: SaveSearchModalProps) {
     },
   });
 
+  const filterEntries = Object.entries(filters);
+
   return (
-    <div className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center" onClick={onClose}>
-      <div className="bg-white rounded-lg p-6 w-96 max-w-[90vw]" onClick={e => e.stopPropagation()}>
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">Save Search</h2>
-        <input
-          type="text"
-          placeholder="Search name..."
-          value={name}
-          onChange={e => setName(e.target.value)}
-          onKeyDown={e => e.key === 'Enter' && name.trim() && saveMutation.mutate()}
-          className="w-full px-3 py-2 text-sm border rounded mb-3 focus:outline-none focus:ring-2 focus:ring-blue-500"
-          autoFocus
-        />
-        <p className="text-xs text-gray-500 mb-4">
-          {Object.entries(filters).map(([k, v]) => `${k}: ${v}`).join(', ')}
-        </p>
-        <div className="flex justify-end gap-2">
-          <button onClick={onClose} className="px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-100 rounded">
-            Cancel
-          </button>
-          <button
-            onClick={() => saveMutation.mutate()}
-            disabled={!name.trim() || saveMutation.isPending}
-            className="px-3 py-1.5 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
-          >
-            Save
-          </button>
+    <div
+      className="fixed inset-0 z-50 bg-stone-900/40 backdrop-blur-sm flex items-center justify-center p-4"
+      onClick={onClose}
+    >
+      <div
+        className="aurora-surface-strong rounded-3xl p-6 w-[440px] max-w-[92vw] shadow-2xl relative overflow-hidden"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="pointer-events-none absolute -top-16 -right-16 h-44 w-44 rounded-full bg-emerald-200/40 blur-3xl" />
+        <div className="pointer-events-none absolute -bottom-12 -left-12 h-40 w-40 rounded-full bg-amber-100/50 blur-3xl" />
+
+        <div className="relative">
+          <p className="text-[11px] uppercase tracking-[0.3em] text-stone-500 font-medium">Watch list</p>
+          <h2 className="font-serif text-3xl text-stone-900 mt-1.5">Save this <span className="italic">search</span></h2>
+          <p className="text-sm text-stone-500 mt-1">We&rsquo;ll let you know when new properties match.</p>
+
+          <div className="mt-5">
+            <label className="block text-[11px] uppercase tracking-wider text-stone-500 mb-1.5 font-medium">Name</label>
+            <input
+              type="text"
+              placeholder="e.g. 3-bd casas under $300K"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              onKeyDown={e => e.key === 'Enter' && name.trim() && saveMutation.mutate()}
+              className="aurora-input w-full"
+              autoFocus
+            />
+          </div>
+
+          {filterEntries.length > 0 && (
+            <div className="mt-4">
+              <p className="text-[11px] uppercase tracking-wider text-stone-500 mb-1.5 font-medium">Filters</p>
+              <div className="flex flex-wrap gap-1.5">
+                {filterEntries.map(([k, v]) => (
+                  <span key={k} className="aurora-chip capitalize">
+                    {k}: <span className="font-medium text-stone-800 normal-case ml-0.5">{v}</span>
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          <div className="flex justify-end gap-2 mt-6">
+            <button onClick={onClose} className="aurora-pill aurora-pill-ghost">
+              Cancel
+            </button>
+            <button
+              onClick={() => saveMutation.mutate()}
+              disabled={!name.trim() || saveMutation.isPending}
+              className="aurora-pill aurora-pill-primary disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              {saveMutation.isPending ? 'Saving…' : 'Save search'}
+            </button>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Roll out a calm sage / cream / charcoal palette and Fraunces serif across every authenticated page. Tokens and surfaces are defined once in `aurora-skin.css` and applied through the `(app)` layout, so any future page picks them up for free.

## What's new

- **Dashboard** — leads with the user's saved searches (latest matches per search, with `+N new` since the last crawl). Inventory flow + category mix render at equal heights in a two-column block. Crawler pulse and price-range histogram were removed (low signal).
- **Saved searches page** — mirrors the dashboard: each saved search is now a panel with the latest 6 matches inline, plus Run / Delete actions and a "+N new" badge.
- **Agent detail** — simplified. Metrics lead, **listings moved to the bottom**, Quality Score dropped, charts repalleted to the new tokens.
- **Listings, listing detail, pipeline, agents list, crawl history, map** — all picked up the same surfaces, chips, pills, and typography.
- **Sidebar** — redesigned with the new palette; cream/sage gradient, Fraunces brand mark, soft active-item highlight. The temporary "Design variants" section is gone.
- **Variant routes removed** — `/v1-aurora`, `/v2-pulse`, `/v3-obsidian` directories deleted; the Aurora dashboard now lives at `/`.

## API

- **New** `GET /api/dashboard/trends` — daily inventory flow (added/removed), top cities, recent crawl runs, price distribution, category share. No schema changes.
- **Reused** `GET /api/dashboard?tab=searches` from the saved-searches page so the panel and dashboard board share the same preview shape.

## Verification

- `npx tsc --noEmit` clean
- All authenticated routes return 200 against the production Coolify Postgres (`/`, `/listings`, `/listings/[id]`, `/pipeline`, `/saved-searches`, `/map`, `/agents`, `/agents/[name]`, `/crawl-history`, `/crawl-history/[id]`); the deleted variant routes return 404.
- Lint surface is unchanged (the remaining warnings are all pre-existing patterns in `db/index.ts`, `ListingCard`, `ListingFilters`).

## Test plan

- [ ] Dashboard renders with saved-searches hero and an equal-height inventory/category row
- [ ] Saved searches page lists each search with its latest 6 matches and a "+N new" badge after a crawl
- [ ] Agent detail leads with metric tiles, listings table sits at the bottom, no Quality Score section
- [ ] Listings/listing detail/pipeline/map/crawl-history all render with the Aurora palette
- [ ] No reference to the old `/v1-aurora`, `/v2-pulse`, `/v3-obsidian` routes anywhere in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)